### PR TITLE
Fixed docker repositories and tags

### DIFF
--- a/charts/etos/charts/environment_provider/values.yaml
+++ b/charts/etos/charts/environment_provider/values.yaml
@@ -6,9 +6,9 @@ replicaCount: 1
 
 image:
   dev:
-    repository: registry.nordix.org/eiffel-playground/etos-environment-provider 
-  prod:
     repository: registry.nordix.org/eiffel-playground/etos-environment-provider
+  prod:
+    repository: registry.nordix.org/eiffel/etos-environment-provider
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/charts/etos/charts/etos-api/values.yaml
+++ b/charts/etos/charts/etos-api/values.yaml
@@ -8,7 +8,7 @@ image:
   dev:
     repository: registry.nordix.org/eiffel-playground/etos-api
   prod:
-    repository: registry.nordix.org/eiffel-playground/etos-api
+    repository: registry.nordix.org/eiffel/etos-api
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/charts/etos/charts/suite-starter/values.yaml
+++ b/charts/etos/charts/suite-starter/values.yaml
@@ -8,7 +8,7 @@ image:
   dev:
     repository: registry.nordix.org/eiffel-playground/etos-suite-starter 
   prod:
-    repository: registry.nordix.org/eiffel-playground/etos-suite-starter
+    repository: registry.nordix.org/eiffel/etos-suite-starter
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/charts/etos/templates/_helpers.tpl
+++ b/charts/etos/templates/_helpers.tpl
@@ -87,10 +87,10 @@ password: {{ printf "%s" .Values.redis.password | b64enc }}
 {{- end }}
 
 {{- define "etos.suiteRunnerContainerImage" -}}
-{{ if .Values.global.development }}
-SUITE_RUNNER: {{ .Values.suiteRunnerContainerImage }}:dev
+{{- if .Values.global.development }}
+SUITE_RUNNER: {{ .Values.suiteRunner.dev.containerImage }}:dev
 {{- else }}
-SUITE_RUNNER: {{ printf "%s:%s" .Values.suiteRunnerContainerImage .Values.suiteRunnerContainerImageTag }}
+SUITE_RUNNER: {{ .Values.suiteRunner.prod.containerImage }}:{{ .Values.suiteRunner.prod.tag | default .Chart.AppVersion }}
 {{- end }}
 {{- end }}
 

--- a/charts/etos/values.yaml
+++ b/charts/etos/values.yaml
@@ -10,8 +10,12 @@ suite-starter:
   rabbitMQ:
     queue_name: suite_starter
 
-suiteRunnerContainerImage: registry.nordix.org/eiffel-playground/etos-suite-runner
-suiteRunnerContainerImageTag: latest 
+suiteRunner:
+  dev:
+    containerImage: "registry.nordix.org/eiffel-playground/etos-suite-runner"
+  prod:
+    containerImage: "registry.nordix.org/eiffel/etos-suite-runner"
+    tag: ""
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
### Applicable Issues
fixes #51 

### Description of the Change
This change sets the default docker production repositories correctly and also makes docker repositories and tags honor the development flag.

### Alternate Designs
N/A

### Benefits
We pull the correct images when deploying a production and/or development release of ETOS

### Possible Drawbacks
N/A

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <fredrik.fristedt@axis.com>
