### PR TITLE
Add filebeat sidecars that can be enabled

### DIFF
--- a/charts/etos/charts/environment_provider/templates/deployment_api.yaml
+++ b/charts/etos/charts/environment_provider/templates/deployment_api.yaml
@@ -13,6 +13,14 @@ spec:
         app: {{ include "environment-provider.name" . }}
         db: redis
     spec:
+      {{- if .Values.global.filebeatSidecar.enabled }}
+      volumes:
+      - name: shared-logs
+        emptyDir: {}
+      - name: filebeat-config
+        configMap:
+          name: sidecar-config
+      {{- end }}
       serviceAccountName: {{ .Values.global.serviceAccount.name }}
       containers:
         - name: {{ include "environment-provider.name" . }}
@@ -38,6 +46,20 @@ spec:
               name: etos          
           ports:
               - containerPort: 80
+        {{- if .Values.global.filebeatSidecar.enabled }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /home/etos/logs
+        - name: sidecar
+          image: {{ .Values.global.filebeatSidecar.image }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/filebeat/logs
+          - name: filebeat-config
+            mountPath: /usr/share/filebeat/filebeat.yml
+            readOnly: true
+            subPath: filebeat.yml
+        {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/etos/charts/environment_provider/templates/deployment_worker.yaml
+++ b/charts/etos/charts/environment_provider/templates/deployment_worker.yaml
@@ -13,6 +13,14 @@ spec:
         app: {{ include "environment-provider.name" . }}-workers
         db: redis
     spec:
+      {{- if .Values.global.filebeatSidecar.enabled }}
+      volumes:
+      - name: shared-logs
+        emptyDir: {}
+      - name: filebeat-config
+        configMap:
+          name: sidecar-config
+      {{- end }}
       serviceAccountName: {{ .Values.global.serviceAccount.name }}
       containers:
         - name: {{ include "environment-provider.name" . }}-workers
@@ -36,6 +44,20 @@ spec:
           envFrom:
           - configMapRef:
               name: etos          
+        {{- if .Values.global.filebeatSidecar.enabled }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /home/etos/logs
+        - name: sidecar
+          image: {{ .Values.global.filebeatSidecar.image }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/filebeat/logs
+          - name: filebeat-config
+            mountPath: /usr/share/filebeat/filebeat.yml
+            readOnly: true
+            subPath: filebeat.yml
+        {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/etos/charts/etos-api/templates/deployment.yaml
+++ b/charts/etos/charts/etos-api/templates/deployment.yaml
@@ -16,25 +16,47 @@ spec:
         app: {{ include "etos-api.name" . }}
         db: redis
     spec:
+      {{- if .Values.global.filebeatSidecar.enabled }}
+      volumes:
+      - name: shared-logs
+        emptyDir: {}
+      - name: filebeat-config
+        configMap:
+          name: sidecar-config
+      {{- end }}
       containers:
-      - name: {{ include "etos-api.name" . }}
-        {{- include "etos.containerImage" . | indent 8 }}
-        envFrom:
-        - configMapRef:
-            name: etos
-        env:
-          - name: RABBITMQ_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: rabbitmq
-                key: password
-          - name: RABBITMQ_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: rabbitmq
-                key: username
-        ports:
-        - containerPort: 80
+        - name: {{ include "etos-api.name" . }}
+          {{- include "etos.containerImage" . | indent 10 }}
+          envFrom:
+          - configMapRef:
+              name: etos
+          env:
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq
+                  key: password
+            - name: RABBITMQ_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq
+                  key: username
+          ports:
+          - containerPort: 80
+        {{- if .Values.global.filebeatSidecar.enabled }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /home/etos/logs
+        - name: sidecar
+          image: {{ .Values.global.filebeatSidecar.image }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/filebeat/logs
+          - name: filebeat-config
+            mountPath: /usr/share/filebeat/filebeat.yml
+            readOnly: true
+            subPath: filebeat.yml
+        {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/etos/charts/suite-starter/templates/deployment.yaml
+++ b/charts/etos/charts/suite-starter/templates/deployment.yaml
@@ -16,6 +16,14 @@ spec:
         app: {{ include "suite-starter.name" . }}
         db: redis
     spec:
+      {{- if .Values.global.filebeatSidecar.enabled }}
+      volumes:
+      - name: shared-logs
+        emptyDir: {}
+      - name: filebeat-config
+        configMap:
+          name: sidecar-config
+      {{- end }}
       serviceAccount: {{ .Values.global.serviceAccount.name }}
       containers:
         - name: {{ include "suite-starter.name" . }}
@@ -36,3 +44,17 @@ spec:
           envFrom:
           - configMapRef:
               name: etos
+        {{- if .Values.global.filebeatSidecar.enabled }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /home/etos/logs
+        - name: sidecar
+          image: {{ .Values.global.filebeatSidecar.image }}
+          volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/filebeat/logs
+          - name: filebeat-config
+            mountPath: /usr/share/filebeat/filebeat.yml
+            readOnly: true
+            subPath: filebeat.yml
+        {{- end }}

--- a/charts/etos/templates/configmap.yaml
+++ b/charts/etos/templates/configmap.yaml
@@ -7,6 +7,9 @@ data:
   DEV: {{ .Values.global.development | quote }}
 
   {{- include "etos.suiteRunnerContainerImage" . | indent 2 }}
+  ETOS_SIDECAR_ENABLED: {{ .Values.global.filebeatSidecar.enabled | quote }}
+  ETOS_SIDECAR_IMAGE: {{ .Values.global.filebeatSidecar.image }}
+
   HTTP_PROXY_OVERRIDE: {{ if eq .Values.httpProxy ""}}""{{ else }}{{ .Values.httpProxy }}{{ end }}
   HTTPS_PROXY_OVERRIDE: {{ if eq .Values.httpsProxy ""}}""{{ else }}{{ .Values.httpsProxy }}{{ end }}
   SOURCE_HOST: {{ include "etos.name" . | upper }}

--- a/charts/etos/templates/sidecar_config.yaml
+++ b/charts/etos/templates/sidecar_config.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.filebeatSidecar.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sidecar-config
+data:
+{{- range $path, $config := .Values.filebeatConfig }}
+  {{ $path }}: |
+{{ tpl $config $ | indent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/charts/etos/values.yaml
+++ b/charts/etos/values.yaml
@@ -5,6 +5,9 @@ global:
   graphqlServerUrl: http://eiffel-graphql.mycluster.myhost.com/graphql
   environmentProviderUrl: http://environment-provider.mycluster.myhost.com
   etosApiUrl: http://etos-api.mycluster.myhost.com
+  filebeatSidecar:
+    enabled: false
+    image: "docker.elastic.co/beats/filebeat:7.10.1"
 
 suite-starter:
   rabbitMQ:
@@ -13,6 +16,17 @@ suite-starter:
 suiteRunner:
   containerImage: "registry.nordix.org/eiffel/etos-suite-runner"
   tag: ""
+
+filebeatConfig:
+  filebeat.yml: |-
+    filebeat.inputs:
+    - type: log
+      paths:
+        /usr/share/filebeat/logs/*
+    processors:
+      - add_host_metadata:
+    output.logstash:
+      hosts: ["logstash-logstash.elasticsearch.svc.cluster.local:5044"]
 
 httpProxy: ""
 httpsProxy: ""


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Fixes: #70 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add filebeat that can be enabled in the helm charts. This is disabled by default.
Not that we do not install ELK in these helm charts and it has to be started outside of ETOS to work.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We should investigate whether we want to add ELK to ETOS as well.

### Benefits
<!-- What benefits will be realized by the change? -->
Centralized logging is always good. This enabled the use of logstash if one has an instance up and running.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Possibly locking ourselves into ELK.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
