### PR TITLE
Add environment provider timeouts

### DIFF
--- a/charts/etos/templates/configmap.yaml
+++ b/charts/etos/templates/configmap.yaml
@@ -45,6 +45,10 @@ data:
   ENVIRONMENT_PROVIDER_EVENT_DATA_TIMEOUT: {{ .Values.environmentProviderEventDataTimeout | quote }}
   ENVIRONMENT_PROVIDER_TEST_SUITE_TIMEOUT: {{ .Values.environmentProviderTestSuiteTimeout | quote }}
 
+  ETOS_WAIT_FOR_LOG_AREA_TIMEOUT: {{ .Values.logAreaTimeout | quote }}
+  ETOS_WAIT_FOR_IUT_TIMEOUT: {{ .Values.iutTimeout | quote }}
+  ETOS_WAIT_FOR_EXECUTION_SPACE_TIMEOUT: {{ .Values.executionSpaceTimeout | quote }}
+
   # Environment provider checks for device every 5s. This means that we should always
   # wait for a longer time than that. Recommended is to add 10s, just to be safe.
   ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT: {{ .Values.esrWaitForEnvironmentTimeout | quote }}

--- a/charts/etos/values.yaml
+++ b/charts/etos/values.yaml
@@ -38,6 +38,9 @@ defaultWaitTimeout: "60"
 defaultTestResultTimeout: "86400"
 publishedEventHistorySize: "100"
 receivedEventHistorySize: "100"
+logAreaTimeout: "10"
+iutTimeout: "10"
+executionSpaceTimeout: "10"
 
 databaseHost: redis.redis.svc.cluster.local
 databasePort: "26379"


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add configuration for the parameters added in this commit: https://github.com/eiffel-community/etos-environment-provider/commit/42cecbc9a085292a11ae0277766c46c05473c6d6

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We should probably allow for users to just add any environment variables, but I don't want to look at this right now.

### Benefits
<!-- What benefits will be realized by the change? -->
We would be able to actually configure ETOS

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
