### PR TITLE
Fix a problem with all logs not being downloaded

### DIFF
--- a/cli/src/etos_client/lib/test_result_handler.py
+++ b/cli/src/etos_client/lib/test_result_handler.py
@@ -177,7 +177,7 @@ class ETOSTestResultHandler:
                 continue
             finished = self.finished(event_id)
             if finished is not None:
-                self.test_suite_started[event_id]["finished"] = finished is not None
+                self.test_suite_started[event_id]["finished"] = True
                 yield finished
 
     def get_events(self):
@@ -194,9 +194,8 @@ class ETOSTestResultHandler:
 
             self.has_started = True
             main_suite_finished = self.finished(main_suite_id)
-            if main_suite_finished in self.main_suites_finished:
-                continue
-            finished = False
+            if main_suite_finished not in self.main_suites_finished:
+                finished = False
 
             for sub_suite_finished in self.collect_sub_suites(main_suite_id):
                 self.test_suites_finished.append(sub_suite_finished)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #144 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make sure we store all sub suites before we check if the main suites have finished.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
The previous design was to keep the requests to ER to a minimum. Something that we should strive for. I found no obvious way of doing that in this PR.

### Benefits
<!-- What benefits will be realized by the change? -->
We won't exit too fast, without downloading all logs anymore.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We hammer the ER a bit more now.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
