### PR TITLE
Make it possible to choose own secrets for db and rabbitmq

### DIFF
--- a/charts/etos/charts/api/templates/deployment.yaml
+++ b/charts/etos/charts/api/templates/deployment.yaml
@@ -41,20 +41,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: password
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: username
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/etos/charts/api/templates/deployment.yaml
+++ b/charts/etos/charts/api/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
           ports:
             - name: http

--- a/charts/etos/charts/api/values.yaml
+++ b/charts/etos/charts/api/values.yaml
@@ -24,9 +24,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "etos-sa"
 
-# This must be the same as the etos chart, as suite starter does not generate
-# its own configmap in this chart. Yet.
+# These must be the same as the etos chart, as the API does not generate
+# its own configmap and secret in this chart. Yet.
 configMap: "etos"
+rabbitmqSecret: "rabbitmq"
 
 # Filebeat is for sending logs to an elastic cluster. It is used to debug
 # messages and to follow a test suite throughout an ETOS execution.

--- a/charts/etos/charts/environment-provider/charts/environment-provider-workers/templates/deployment.yaml
+++ b/charts/etos/charts/environment-provider/charts/environment-provider-workers/templates/deployment.yaml
@@ -44,9 +44,9 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingDatabaseSecret | default .Values.databaseSecret }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/etos/charts/environment-provider/charts/environment-provider-workers/templates/deployment.yaml
+++ b/charts/etos/charts/environment-provider/charts/environment-provider-workers/templates/deployment.yaml
@@ -41,25 +41,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: ETOS_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: redis
-                  key: password
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: password
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: username
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingDatabaseSecret | default .Values.databaseSecret }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.filebeat.enabled }}

--- a/charts/etos/charts/environment-provider/charts/environment-provider-workers/values.yaml
+++ b/charts/etos/charts/environment-provider/charts/environment-provider-workers/values.yaml
@@ -24,9 +24,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "etos-sa"
 
-# This must be the same as the etos chart, as suite starter does not generate
-# its own configmap in this chart. Yet.
+# These must be the same as the etos chart, as environment provider does not generate
+# its own configmap and secret in this chart. Yet.
 configMap: "etos"
+rabbitmqSecret: "rabbitmq"
+databaseSecret: "database"
 
 # Filebeat is for sending logs to an elastic cluster. It is used to debug
 # messages and to follow a test suite throughout an ETOS execution.

--- a/charts/etos/charts/environment-provider/templates/deployment.yaml
+++ b/charts/etos/charts/environment-provider/templates/deployment.yaml
@@ -44,9 +44,9 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingDatabaseSecret | default .Values.databaseSecret }}
           ports:
             - name: http

--- a/charts/etos/charts/environment-provider/templates/deployment.yaml
+++ b/charts/etos/charts/environment-provider/templates/deployment.yaml
@@ -41,25 +41,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: ETOS_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: redis
-                  key: password
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: password
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: username
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingDatabaseSecret | default .Values.databaseSecret }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/etos/charts/environment-provider/values.yaml
+++ b/charts/etos/charts/environment-provider/values.yaml
@@ -24,9 +24,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "etos-sa"
 
-# This must be the same as the etos chart, as suite starter does not generate
-# its own configmap in this chart. Yet.
+# These must be the same as the etos chart, as environment provider does not generate
+# its own configmap and secret in this chart. Yet.
 configMap: "etos"
+rabbitmqSecret: "rabbitmq"
+databaseSecret: "database"
 
 # Filebeat is for sending logs to an elastic cluster. It is used to debug
 # messages and to follow a test suite throughout an ETOS execution.

--- a/charts/etos/charts/suite-starter/templates/deployment.yaml
+++ b/charts/etos/charts/suite-starter/templates/deployment.yaml
@@ -46,19 +46,11 @@ spec:
               value: {{ .Values.rabbitmq.queue_name }}
             - name: RABBITMQ_ROUTING_KEY
               value: {{ .Values.rabbitmq.routing_key }}
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: username
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq
-                  key: password
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
+          - secretKeyRef:
+              name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.filebeat.enabled }}

--- a/charts/etos/charts/suite-starter/templates/deployment.yaml
+++ b/charts/etos/charts/suite-starter/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Values.configMap }}
-          - secretKeyRef:
+          - secretRef:
               name: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/etos/charts/suite-starter/values.yaml
+++ b/charts/etos/charts/suite-starter/values.yaml
@@ -31,9 +31,10 @@ rabbitmq:
   queue_name: suite_starter
   routing_key: "#"
 
-# This must be the same as the etos chart, as suite starter does not generate
-# its own configmap in this chart. Yet.
+# These must be the same as the etos chart, as suite starter does not generate
+# its own configmap and secret in this chart. Yet.
 configMap: "etos"
+rabbitmqSecret: "rabbitmq"
 
 # Filebeat is for sending logs to an elastic cluster. It is used to debug
 # messages and to follow a test suite throughout an ETOS execution.

--- a/charts/etos/templates/_helpers.tpl
+++ b/charts/etos/templates/_helpers.tpl
@@ -23,6 +23,10 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "environment-provider.rabbitmqSecret" -}}
+{{ .Values.rabbitmqSecret }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/etos/templates/_helpers.tpl
+++ b/charts/etos/templates/_helpers.tpl
@@ -23,10 +23,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{- define "environment-provider.rabbitmqSecret" -}}
-{{ .Values.rabbitmqSecret }}
-{{- end }}
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/etos/templates/configmap.yaml
+++ b/charts/etos/templates/configmap.yaml
@@ -24,16 +24,8 @@ data:
 
   ETOS_NAMESPACE: {{ .Release.Namespace}}
   ETOS_CONFIGMAP: {{ .Values.configMap }}
+  ETOS_RABBITMQ_SECRET: {{ .Values.global.existingRabbitmqSecret | default .Values.rabbitmqSecret }}
   ETOS_ROUTING_KEY_TAG: {{ .Values.routingKey.tag }}
-
-  RABBITMQ_HOST: {{ required "Please set `rabbitmq.host`" .Values.rabbitmq.host }}
-  RABBITMQ_EXCHANGE: {{ required "Please set `rabbitmq.exchange`" .Values.rabbitmq.exchange }}
-  RABBITMQ_PORT: {{ required "Please set `rabbitmq.port`" .Values.rabbitmq.port | quote }}
-  RABBITMQ_VHOST: {{ required "Please set `rabbitmq.vhost`" .Values.rabbitmq.vhost }}
-  RABBITMQ_SSL: {{ required "Please set `rabbitmq.ssl`" .Values.rabbitmq.ssl | quote }}
-
-  ETOS_DATABASE_HOST: {{ required "Please set `database.host`" .Values.database.host }}
-  ETOS_DATABASE_PORT: {{ required "Please set `database.port`" .Values.database.port | quote }}
 
   {{- if .Values.config }}
   {{- range $key, $value := .Values.config }}

--- a/charts/etos/templates/database_secret.yaml
+++ b/charts/etos/templates/database_secret.yaml
@@ -1,9 +1,13 @@
+{{- if eq .Values.global.existingDatabaseSecret "" -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: redis
+  name: {{ .Values.databaseSecret }}
   labels:
     {{- include "etos.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ .Values.database.password | default "" | b64enc }}
+  ETOS_DATABASE_PASSWORD: {{ .Values.database.password | default "" | b64enc }}
+  ETOS_DATABASE_HOST: {{ required "Please set `database.host`" .Values.database.host }}
+  ETOS_DATABASE_PORT: {{ required "Please set `database.port`" .Values.database.port | quote }}
+{{- end }}

--- a/charts/etos/templates/rabbitmq_secret.yaml
+++ b/charts/etos/templates/rabbitmq_secret.yaml
@@ -1,10 +1,18 @@
+{{- if eq .Values.global.existingRabbitmqSecret "" -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rabbitmq
+  name: {{ .Values.rabbitmqSecret }}
   labels:
     {{- include "etos.labels" . | nindent 4 }}
 type: Opaque
 data:
-  username: {{ .Values.rabbitmq.username | default "" | b64enc }}
-  password: {{ .Values.rabbitmq.password | default "" | b64enc }}
+  RABBITMQ_USERNAME: {{ .Values.rabbitmq.username | default "" | b64enc }}
+  RABBITMQ_PASSWORD: {{ .Values.rabbitmq.password | default "" | b64enc }}
+stringData:
+  RABBITMQ_HOST: {{ required "Please set `rabbitmq.host`" .Values.rabbitmq.host }}
+  RABBITMQ_EXCHANGE: {{ required "Please set `rabbitmq.exchange`" .Values.rabbitmq.exchange }}
+  RABBITMQ_PORT: {{ required "Please set `rabbitmq.port`" .Values.rabbitmq.port | quote }}
+  RABBITMQ_VHOST: {{ required "Please set `rabbitmq.vhost`" .Values.rabbitmq.vhost }}
+  RABBITMQ_SSL: {{ required "Please set `rabbitmq.ssl`" .Values.rabbitmq.ssl | quote }}
+{{- end }}

--- a/charts/etos/values.yaml
+++ b/charts/etos/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 global:
   development: true
+  existingRabbitmqSecret: ""
+  existingDatabaseSecret: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -85,6 +87,7 @@ database: {}
   # host:
   # port:
   # password:
+databaseSecret: "database"
 
 # RabbitMQ is used to send and receive Eiffel events.
 rabbitmq: {}
@@ -95,6 +98,7 @@ rabbitmq: {}
   # ssl:
   # username:
   # password:
+rabbitmqSecret: "rabbitmq"
 
 featureFlags: {}
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add the possibility to choose own secrets for rabbitmq and database.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I don't like the use of global, but having the users add the secret value to each chart would be too failure-prone.

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow users to deploy ETOS using other secret management than just regular kubernetes secrets. For example sealedsecrets.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None, really.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
