### PR TITLE
Exit on client errors

### DIFF
--- a/cli/src/etos_client/__main__.py
+++ b/cli/src/etos_client/__main__.py
@@ -174,7 +174,7 @@ def check_etos_connectivity(url):
         response = requests.get(url, timeout=5)
         response.raise_for_status()
     except Exception as exception:  # pylint:disable=broad-except
-        raise Exception(
+        raise Exception(  # pylint:disable=broad-exception-raised
             "Unable to connect to ETOS. Please check your network connection."
         ) from exception
 

--- a/cli/src/etos_client/client.py
+++ b/cli/src/etos_client/client.py
@@ -134,6 +134,8 @@ class ETOSClient:
                         response_json = {"detail": "Unknown client error from ETOS"}
                     spinner.fail(response_json.get("detail"))
                     return False
+                traceback.print_exc()
+                time.sleep(2)
             except (
                 ConnectionError,
                 NewConnectionError,

--- a/cli/src/etos_client/client.py
+++ b/cli/src/etos_client/client.py
@@ -131,6 +131,7 @@ class ETOSClient:
                     try:
                         response_json = response.json()
                     except JSONDecodeError:
+                        spinner.info(f"Raw response from ETOS: {response.text!r}")
                         response_json = {"detail": "Unknown client error from ETOS"}
                     spinner.fail(response_json.get("detail"))
                     return False


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #156 
fixes: #114 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Exit when the ETOS API returns a client error (>=400<500).

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I decided to remove the dependency to the ETOS library http wait method since it just caught every exception without allowing the ETOS client to handle certain errors.

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow the client to exit with a clear error message any time an error with input is caught by the ETOS API.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can think of

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
