### PR TITLE
Logs from log proxy

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -15,5 +15,5 @@
 # numpy==1.13.3
 # scipy==1.0
 #
-packageurl-python==0.9.1
+sseclient==0.0.27
 etos_lib==2.1.0

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -29,7 +29,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    packageurl-python==0.9.1
+    sseclient==0.0.27
     etos_lib==2.1.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/cli/src/etos_client/__main__.py
+++ b/cli/src/etos_client/__main__.py
@@ -17,7 +17,6 @@
 """Main executable module."""
 import argparse
 import sys
-import time
 import os
 import logging
 import warnings
@@ -30,12 +29,13 @@ from etos_client.events.collector import Collector
 from etos_client.etos.schema import RequestSchema
 from etos_client.etos import ETOS
 from etos_client.test_results import TestResults
-from etos_client.announcer import Announcer
 from etos_client.downloader import Downloader
 from etos_client.event_repository import graphql
+from etos_client.test_run import TestRun
 
 LOGGER = logging.getLogger(__name__)
-HOUR = 3600
+MINUTE = 60
+HOUR = MINUTE * 60
 
 
 def environ_or_required(key: str) -> dict:
@@ -157,7 +157,7 @@ def setup_logging(loglevel: int) -> None:
     )
 
 
-def main(args: list[str]) -> None:  # pylint:disable=too-many-statements
+def main(args: list[str]) -> None:
     """Entry point allowing external calls."""
     args = parse_args(args)
     if args.download_reports:
@@ -176,45 +176,26 @@ def main(args: list[str]) -> None:  # pylint:disable=too-many-statements
 
     LOGGER.info("Running in cluster: %r", args.cluster)
     etos_library = ETOSLibrary("ETOS Client", os.getenv("HOSTNAME"), "ETOS Client")
-    collector = Collector(etos_library, graphql)
 
     etos = ETOS(args.cluster)
     response = etos.start(RequestSchema.from_args(args))
     if not response:
         sys.exit(etos.reason)
-
-    LOGGER.info("Suite ID: %s", response.tercc)
-    LOGGER.info("Artifact ID: %s", response.artifact_id)
-    LOGGER.info("Purl: %s", response.artifact_identity)
     os.environ["ETOS_GRAPHQL_SERVER"] = response.event_repository
-    LOGGER.info("Event repository: %r", response.event_repository)
 
-    test_results = TestResults()
-    log_downloader = Downloader()
-    announcer = Announcer()
-
+    collector = Collector(etos_library, graphql)
+    log_downloader = Downloader(report_dir, artifact_dir)
     log_downloader.start()
+    try:
+        test_run = TestRun(collector, log_downloader)
+        test_run.setup_logging(args.loglevel)
+        events = test_run.track(etos, 24 * HOUR)
 
-    timeout = time.time() + HOUR * 24
-    while time.time() < timeout:
-        events = collector.collect(response.tercc)
-        if events.activity.canceled:
-            sys.exit(events.activity.canceled["data"]["reason"])
-        if events.activity.finished:
-            break
-        announcer.announce(events)
-        if events.main_suites:
-            log_downloader.download_logs(events.main_suites, report_dir)
-        log_downloader.download_artifacts(events.artifacts, artifact_dir)
-        time.sleep(10)
-
-    events = collector.collect(response.tercc)
-    if events.main_suites:
-        log_downloader.download_logs(events.main_suites, report_dir)
-    log_downloader.download_artifacts(events.artifacts, artifact_dir)
-
-    log_downloader.stop()
-    log_downloader.join()
+        log_downloader.stop()
+        log_downloader.join()
+    finally:
+        log_downloader.stop(clear_queue=False)
+        log_downloader.join()
 
     LOGGER.info("Archiving reports.")
     shutil.make_archive(
@@ -226,7 +207,7 @@ def main(args: list[str]) -> None:  # pylint:disable=too-many-statements
     if log_downloader.failed:
         sys.exit("ETOS logs did not download successfully.")
 
-    result, message = test_results.get_results(events)
+    result, message = TestResults().get_results(events)
     if result:
         LOGGER.info(message)
     else:

--- a/cli/src/etos_client/__main__.py
+++ b/cli/src/etos_client/__main__.py
@@ -31,7 +31,7 @@ from etos_client.etos.schema import RequestSchema
 from etos_client.etos import ETOS
 from etos_client.test_results import TestResults
 from etos_client.announcer import Announcer
-from etos_client.logs import LogDownloader
+from etos_client.downloader import Downloader
 from etos_client.event_repository import graphql
 
 LOGGER = logging.getLogger(__name__)
@@ -190,7 +190,7 @@ def main(args: list[str]) -> None:  # pylint:disable=too-many-statements
     LOGGER.info("Event repository: %r", response.event_repository)
 
     test_results = TestResults()
-    log_downloader = LogDownloader()
+    log_downloader = Downloader()
     announcer = Announcer()
 
     log_downloader.start()

--- a/cli/src/etos_client/downloader/__init__.py
+++ b/cli/src/etos_client/downloader/__init__.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS Client log downloader module."""
-from .logs import LogDownloader
+from .downloader import Downloader

--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -64,7 +64,7 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         end_time = time.time() + 30
         while time.time() < end_time:
             response = requests.get(item.uri, stream=True, timeout=10)
-            self.logger.debug(response)
+            self.logger.debug("Download response: %r", response)
             if self.__should_retry(response):
                 self.logger.warning("Download failed. Retrying..")
                 time.sleep(2)
@@ -106,7 +106,7 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
                     response_json = {
                         "detail": "Unknown client error when downloading files from log area"
                     }
-                self.logger.critical(response_json)
+                self.logger.critical("Download response: %r", response_json)
                 return False
             return True
         except (
@@ -172,7 +172,7 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
             self.__queued.append(item.uri)
 
     def download_artifacts(self, artifacts: list[Artifact]) -> None:
-        """Download artifacts to a artifact path."""
+        """Download artifacts to an artifact path."""
         for artifact in artifacts:
             for _file in artifact.files:
                 filepath = self.__artifact_dir.joinpath(

--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -39,7 +39,7 @@ class Downloadable(BaseModel):
     name: Optional[Path]
 
 
-class LogDownloader(Thread):
+class Downloader(Thread):
     """Log downloader for ETOS client."""
 
     logger = logging.getLogger(__name__)

--- a/cli/src/etos_client/etos/etos.py
+++ b/cli/src/etos_client/etos/etos.py
@@ -31,6 +31,7 @@ class ETOS:  # pylint:disable=too-few-public-methods
 
     logger = logging.getLogger(__name__)
     reason = ""
+    response: ResponseSchema = None
 
     def __init__(self, cluster: str) -> None:
         """Initialize ETOS."""
@@ -44,11 +45,11 @@ class ETOS:  # pylint:disable=too-few-public-methods
             return None
         self.logger.info("Connection successful.")
         self.logger.info("Triggering ETOS.")
-        response = self.__start(request_data)
-        if not response:
+        self.response = self.__start(request_data)
+        if not self.response:
             self.reason = "Failed to start ETOS"
             return None
-        return response
+        return self.response
 
     def __check_connection(self) -> bool:
         """Check connection to ETOS."""

--- a/cli/src/etos_client/logs/__init__.py
+++ b/cli/src/etos_client/logs/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS sse log module."""
+from .logs import Message, Ping, Logs

--- a/cli/src/etos_client/logs/logs.py
+++ b/cli/src/etos_client/logs/logs.py
@@ -1,0 +1,100 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Get ETOS sse logs."""
+import traceback
+import time
+import json
+import logging
+from datetime import datetime
+from typing import Iterator, Union
+
+import requests
+from sseclient import SSEClient
+
+from etos_client.etos import ETOS
+
+# pylint: disable=too-few-public-methods
+
+
+class Ping:
+    """ETOS log API ping."""
+
+
+class Message:
+    """An ETOS log message."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize fields that are necessary to log an ETOS message."""
+        self.message = json.loads(message)
+        self.level = self.message.get("levelname", "INFO").lower()
+        self.name = self.message.get("name")
+        dtime = datetime.strptime(
+            self.message.get("@timestamp"), "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        self.datestring = datetime.strftime(dtime, "%Y-%m-%d %H:%M:%S")
+
+    def __str__(self) -> str:
+        """Message part of an ETOS message."""
+        return self.message.get("message")
+
+
+class Logs:
+    """Connect to ETOS log API and print all logs from ETOS."""
+
+    logger = logging.getLogger(__name__)
+    __events = None
+    __current_id = 0
+
+    def connect_to_log_server(self, etos: ETOS, timeout: int) -> None:
+        """Connect to the ETOS log server."""
+        while time.time() < timeout:
+            try:
+                self.__events = SSEClient(
+                    f"{etos.cluster}/logs/{str(etos.response.tercc)}"
+                )
+                break
+            except requests.exceptions.HTTPError as http_error:
+                if http_error.response.status_code != 404:
+                    traceback.print_exc()
+                time.sleep(2)
+
+    def logs(self, timeout: int) -> Iterator[Union[Message, Ping]]:
+        """Connect to log server and collect logs from it."""
+        try:
+            for event in self.__events:
+                if event.data:
+                    event_id = int(event.id)
+                    if event_id <= self.__current_id:
+                        # When the SSE client reconnects all messages will be returned
+                        # again. Tracking the IDs so that we don't print them unnecessarily.
+                        self.logger.debug(
+                            "Ignoring message with id %d because it has already been logged",
+                            event_id,
+                        )
+                        continue
+                    self.__current_id = event_id
+                    yield Message(event.data)
+                else:
+                    # Pings are expected, by default, to come at a 15s interval.
+                    yield Ping()
+                if time.time() >= timeout:
+                    raise TimeoutError("Timed out!")
+        except requests.exceptions.ChunkedEncodingError:
+            traceback.print_exc()
+        except requests.exceptions.HTTPError as http_error:
+            if http_error.response.status_code == 404:
+                return
+            raise

--- a/cli/src/etos_client/test_run/__init__.py
+++ b/cli/src/etos_client/test_run/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS test run module."""
+from .test_run import TestRun

--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -1,0 +1,130 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS test run handler."""
+import sys
+import time
+import logging
+from typing import Iterator
+from etos_client.events.collector import Collector
+from etos_client.events.events import Events
+from etos_client.etos import ETOS
+from etos_client.etos.schema import ResponseSchema
+from etos_client.logs import Message, Ping, Logs
+from etos_client.downloader import Downloader
+from etos_client.announcer import Announcer
+
+
+MINUTE = 60
+
+
+class TestRun:
+    """Track an ETOS test run and log relevant information."""
+
+    logger = logging.getLogger(__name__)
+    remote_logger = logging.getLogger("ETOS")
+
+    def __init__(self, collector: Collector, downloader: Downloader) -> None:
+        """Initialize."""
+        assert (
+            downloader.started
+        ), "Downloader must be started before it can be used in TestRun"
+
+        self.__collector = collector
+        self.__downloader = downloader
+        self.__announcer = Announcer()
+
+    def setup_logging(self, loglevel: int) -> None:
+        """Set up logging for ETOS remote logs."""
+        rhandler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter(
+            fmt="[%(rtime)s] %(levelname)s:%(rname)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        rhandler.setFormatter(formatter)
+        rhandler.setLevel(loglevel)
+        self.remote_logger.propagate = False
+        self.remote_logger.addHandler(rhandler)
+
+    def __log_debug_information(self, response: ResponseSchema) -> None:
+        """Log debug information from the ETOS API response."""
+        self.logger.info("Suite ID: %s", response.tercc)
+        self.logger.info("Artifact ID: %s", response.artifact_id)
+        self.logger.info("Purl: %s", response.artifact_identity)
+        self.logger.info("Event repository: %r", response.event_repository)
+
+    def track(self, etos: ETOS, timeout: int) -> Events:
+        """Track, and wait for, an ETOS test run."""
+        end = time.time() + timeout
+
+        self.__log_debug_information(etos.response)
+        for _ in self.__log_until_eof(etos, end):
+            events = self.__collect(etos)
+            self.__status(events)
+            self.__announce(events)
+            self.__download(events)
+        self.__wait(etos, end)
+        events = self.__collect(etos)
+        self.__download(events)
+        return events
+
+    def __wait(self, etos: ETOS, timeout: int) -> None:
+        """Wait for ETOS to finish its activity."""
+        events = self.__collect(etos)
+        while not events.activity.finished:
+            self.logger.info("Waiting for ETOS to finish")
+            time.sleep(5)
+            if time.time() >= timeout:
+                raise TimeoutError("ETOS did not complete in 24 hours. Exiting")
+            events = self.__collect(etos)
+
+    def __status(self, events: Events) -> None:
+        """Check if ETOS test run has been canceled."""
+        if events.activity.canceled:
+            raise SystemExit(events.activity.canceled["data"]["reason"])
+
+    def __announce(self, events: Events) -> None:
+        """Announce current state of ETOS."""
+        self.__announcer.announce(events)
+
+    def __download(self, events: Events) -> None:
+        """Download logs and artifacts."""
+        if events.main_suites:
+            self.__downloader.download_logs(events.main_suites)
+        self.__downloader.download_artifacts(events.artifacts)
+
+    def __collect(self, etos: ETOS) -> Events:
+        """Collect events from ETOS."""
+        return self.__collector.collect(etos.response.tercc)
+
+    def __log(self, message: Message):
+        logger = getattr(self.remote_logger, message.level)
+        logger(
+            message,
+            extra={
+                "rname": message.name,
+                "rtime": message.datestring,
+            },
+        )
+
+    def __log_until_eof(self, etos: ETOS, timeout: int) -> Iterator[Ping]:
+        """Log from the ETOS log API until finished."""
+        logs = Logs()
+        logs.connect_to_log_server(etos, time.time() + 10 * MINUTE)
+        for log_message in logs.logs(timeout):
+            if isinstance(log_message, Message):
+                self.__log(log_message)
+                continue
+            yield log_message

--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -109,7 +109,8 @@ class TestRun:
         """Collect events from ETOS."""
         return self.__collector.collect(etos.response.tercc)
 
-    def __log(self, message: Message):
+    def __log(self, message: Message) -> None:
+        """Log a message from the ETOS log API."""
         logger = getattr(self.remote_logger, message.level)
         logger(
             message,
@@ -119,11 +120,11 @@ class TestRun:
             },
         )
 
-    def __log_until_eof(self, etos: ETOS, timeout: int) -> Iterator[Ping]:
+    def __log_until_eof(self, etos: ETOS, endtime: int) -> Iterator[Ping]:
         """Log from the ETOS log API until finished."""
         logs = Logs()
         logs.connect_to_log_server(etos, time.time() + 10 * MINUTE)
-        for log_message in logs.logs(timeout):
+        for log_message in logs.logs(endtime):
             if isinstance(log_message, Message):
                 self.__log(log_message)
                 continue


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Depends-on: eiffel-community/etos-api#41
#148 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Connect to ETOS log proxy and get logs from running ETOS test runs.
For reviewing it is recommended to review the commits in isolation as the, now, Downloader was renamed from Logs to Downloader in order for this new module to be named Logs. The full diff looks weird :) 

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I decided to keep the old messages as they are, since they still keep some valuable information. They should be removed in the future (speaking specifically about the announcer).

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow ETOS client to give better information when certain ETOS components are stuck in internal work.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Another dependency for logs and events. We should replace the event repository queries to use the ETOS API in the future.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
