### PR TITLE
Add sub suite folder to artifact download path

### DIFF
--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -176,8 +176,10 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         for artifact in artifacts:
             for _file in artifact.files:
                 filepath = self.__artifact_dir.joinpath(
-                    f"{artifact.suite_name}_{_file}"
+                    f"{artifact.suite_name}"
                 ).relative_to(Path.cwd())
+                filepath.mkdir(exist_ok=True)
+                filepath = filepath.joinpath(_file)
                 self.__queue_download(
                     Downloadable(uri=f"{artifact.location}/{_file}", name=filepath)
                 )


### PR DESCRIPTION
### Description of the Change
In some cases, the names of the test case artifacts can become quite long, with various components and/or services in a test pipeline adding their "uniqueness" to the name to prevent conflicting names and potential data loss. If we're unlucky we override the max length of a filename and in that case the client crashes. A first step to handle this is to put the divide the test artifacts into folders named after the sub suite form which they originate. This will most likely fix any immediate artifact naming problems, but it would still be possible to exceed max length and cause a crash.

### Alternate Designs
Truncating the name and adding yet another uniqness string to the filename would certainly be possible although by retaining the name we probably keep more of the intended file name information and don't potentially loose data that can help users find and correlate artifact files with the test run.

### Benefits
Make the etos client less prone to crashes due to too long filenames for test artifacts.

### Possible Drawbacks
The sub suite folder naming might not be intuitive to a potential user since we cannot assume that they know about the inner workings of ETOS and its sub suites concept.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
