### PR TITLE
Add status check for Activity Canceled Event

### DIFF
--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -85,6 +85,7 @@ class TestRun:
         events = self.__collect(etos)
         while not events.activity.finished:
             self.logger.info("Waiting for ETOS to finish")
+            self.__status(events)
             time.sleep(5)
             if time.time() >= timeout:
                 raise TimeoutError("ETOS did not complete in 24 hours. Exiting")


### PR DESCRIPTION
### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
When client is waiting for Activity Finished, we also need to check if the activity has been canceled, else this will in certain cases cause an unnecessary 24h wait until timeout is reached.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Nope

### Benefits
Test runs that don't get ahold of a test environment within the configure IUT checkout timeout period will not wait for 24h timeout to hit, instead they now react and exit on the Activity Cancel sent in this case.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
