### PR TITLE
Clean up timestamps from ETOS

### DIFF
--- a/cli/src/etos_client/logs/logs.py
+++ b/cli/src/etos_client/logs/logs.py
@@ -19,6 +19,7 @@ import time
 import json
 import logging
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from typing import Iterator, Union
 
 import requests
@@ -41,9 +42,14 @@ class Message:
         self.message = json.loads(message)
         self.level = self.message.get("levelname", "INFO").lower()
         self.name = self.message.get("name")
+
+        # ETOS library will always format the timestamps as ISO8601 UTC
+        # https://github.com/eiffel-community/etos-library/blob/main/src/etos_lib/logging/formatter.py
         dtime = datetime.strptime(
             self.message.get("@timestamp"), "%Y-%m-%dT%H:%M:%S.%fZ"
-        )
+        ).replace(tzinfo=ZoneInfo("UTC"))
+        dtime = dtime.astimezone()
+
         self.datestring = datetime.strftime(dtime, "%Y-%m-%d %H:%M:%S")
 
     def __str__(self) -> str:


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
#148 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Clean up timestamps to follow the OS timezone. ETOS library will always send the timestamp as UTC, so we will assume that is always the case.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
No more time travel between ETOS services.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
