### PR TITLE
Cleanup logging in etos

### DIFF
--- a/cli/src/etos_client/announcer/announcer.py
+++ b/cli/src/etos_client/announcer/announcer.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """Announcer module."""
 import logging
-from etos_client.events.events import Events, TestSuite
+from etos_client.events.events import Events
 
 
 class Announcer:  # pylint:disable=too-few-public-methods
@@ -23,31 +23,65 @@ class Announcer:  # pylint:disable=too-few-public-methods
 
     logger = logging.getLogger(__name__)
 
-    def __etos_state_information(self, test_suites: list[TestSuite]) -> str:
-        """Generate text based on ETOS state."""
-        message_template = (
-            "Started : {started_length}\t" "Finished: {finished_length}\t"
+    def __failed(self, test_cases_finished: list[dict]) -> int:
+        """Failed test case count."""
+        failed = 0
+        for test_case in test_cases_finished:
+            if test_case["data"]["testCaseOutcome"]["verdict"] != "PASSED":
+                failed += 1
+        return failed
+
+    def __build_announcement(self, events: Events) -> str:
+        """Build an announcement based on executed test cases and results."""
+        nbr_of_executed = len(events.test_cases)
+        if nbr_of_executed == 0:
+            return "Still waiting for the first test cases to execute"
+
+        message = f"Number of test cases executed: {nbr_of_executed}"
+
+        detailed = []
+
+        finished = [
+            test_case.finished for test_case in events.test_cases if test_case.finished
+        ]
+        nbr_of_failed = self.__failed(finished)
+        if nbr_of_failed > 0:
+            detailed.append(f"failed={nbr_of_failed}")
+        nbr_of_canceled = len(
+            [
+                test_case.canceled
+                for test_case in events.test_cases
+                if test_case.canceled
+            ]
         )
+        if nbr_of_canceled > 0:
+            detailed.append(f"skipped={nbr_of_canceled}")
 
-        started_length = 0
-        finished_length = 0
-        for test_suite in test_suites:
-            for sub_suite in test_suite.sub_suites:
-                started_length += 1
-                if sub_suite.finished:
-                    finished_length += 1
+        if detailed:
+            message += f" ({', '.join(detailed)})"
+        return message
 
-        params = {
-            "started_length": started_length,
-            "finished_length": finished_length,
-        }
-        return message_template.format(**params)
-
-    def announce(self, events: Events) -> None:
+    def announce(self, events: Events, logs: set) -> None:
         """Announce the ETOS state."""
         if not events.tercc:
+            self.logger.info("Waiting for ETOS to start.")
             return
         if not events.activity.triggered:
+            self.logger.info("Waiting for ETOS to start.")
             return
-        if events.main_suites:
-            self.logger.info(self.__etos_state_information(events.main_suites))
+        if not events.main_suites:
+            self.logger.info("Waiting for main suites to start.")
+            return
+        sub_suites_started = False
+        for main_suite in events.main_suites:
+            if main_suite.sub_suites:
+                sub_suites_started = True
+        if not sub_suites_started:
+            self.logger.info("Waiting for sub suites to start.")
+            return
+
+        self.logger.info(self.__build_announcement(events))
+        if logs:
+            self.logger.info(
+                "Downloaded a total of %d logs from test runners", len(logs)
+            )

--- a/cli/src/etos_client/announcer/announcer.py
+++ b/cli/src/etos_client/announcer/announcer.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """Announcer module."""
 import logging
-from etos_client.events.events import Events, TestSuite, Announcement
+from etos_client.events.events import Events, TestSuite
 
 
 class Announcer:  # pylint:disable=too-few-public-methods
@@ -23,28 +23,11 @@ class Announcer:  # pylint:disable=too-few-public-methods
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self):
-        """Init."""
-        self.__already_logged = []
-
-    def __log_announcements(self, announcements: list[Announcement]) -> None:
-        """Get latest new announcements."""
-        for announcement in announcements:
-            if announcement not in self.__already_logged:
-                self.__already_logged.append(announcement)
-                self.logger.info("%s: %s", announcement.heading, announcement.body)
-
     def __etos_state_information(self, test_suites: list[TestSuite]) -> str:
         """Generate text based on ETOS state."""
         message_template = (
-            "{announcement}\t"
-            "Started : {started_length}\t"
-            "Finished: {finished_length}\t"
+            "Started : {started_length}\t" "Finished: {finished_length}\t"
         )
-        try:
-            announcement = self.__already_logged[-1].body
-        except (KeyError, IndexError, TypeError):
-            announcement = ""
 
         started_length = 0
         finished_length = 0
@@ -57,7 +40,6 @@ class Announcer:  # pylint:disable=too-few-public-methods
         params = {
             "started_length": started_length,
             "finished_length": finished_length,
-            "announcement": announcement,
         }
         return message_template.format(**params)
 
@@ -67,6 +49,5 @@ class Announcer:  # pylint:disable=too-few-public-methods
             return
         if not events.activity.triggered:
             return
-        self.__log_announcements(events.announcements)
         if events.main_suites:
             self.logger.info(self.__etos_state_information(events.main_suites))

--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -53,7 +53,8 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         self.__exit = False
         self.__clear_queue = True
         self.__lock = Lock()
-        self.failed = False
+        self.failed: bool = False
+        self.downloads: {str} = set()
 
         self.__report_dir = report_dir
         self.__artifact_dir = artifact_dir
@@ -89,6 +90,8 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
             index += 1
             download_name = download_name.with_name(f"{index}_{item.name.name}")
         self.logger.debug("Saving file %s", download_name)
+        with self.__lock:
+            self.downloads.add(download_name)
         with open(download_name, "wb+") as report:
             for chunk in response:
                 report.write(chunk)

--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -60,13 +60,13 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
 
     def __retry_download(self, item: Downloadable) -> None:
         """Download files."""
-        self.logger.info("Downloading %r", item)
+        self.logger.debug("Downloading %r", item)
         end_time = time.time() + 60
         while time.time() < end_time:
             response = requests.get(item.uri, stream=True, timeout=10)
             self.logger.debug("Download response: %r", response)
             if self.__should_retry(response):
-                self.logger.warning("Download of %r failed. Retrying..", item)
+                self.logger.debug("Download of %r failed. Retrying..", item)
                 time.sleep(10)
                 continue
             if not response.ok:
@@ -88,7 +88,7 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         while download_name.exists():
             index += 1
             download_name = download_name.with_name(f"{index}_{item.name.name}")
-        self.logger.info("Saving file %s", download_name)
+        self.logger.debug("Saving file %s", download_name)
         with open(download_name, "wb+") as report:
             for chunk in response:
                 report.write(chunk)
@@ -106,7 +106,7 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
                 try:
                     response_json = response.json()
                 except JSONDecodeError:
-                    self.logger.info("Raw response from download: %r", response.text)
+                    self.logger.debug("Raw response from download: %r", response.text)
                     response_json = {
                         "detail": "Unknown client error when downloading files from log area"
                     }

--- a/cli/src/etos_client/event_repository/graphql_queries.py
+++ b/cli/src/etos_client/event_repository/graphql_queries.py
@@ -132,14 +132,56 @@ TEST_SUITE_FINISHED = """
 """
 
 
-ANNOUNCEMENTS = """
+TEST_CASE_FINISHED = """
 {
-  announcementPublished(%s) {
+  testCaseFinished(%s) {
     edges {
       node {
         data {
-          heading
-          body
+          testCaseOutcome {
+            conclusion
+            verdict
+          }
+        }
+        links {
+          ... on TestCaseExecution {
+            testCaseTriggered {
+              data {
+                testCase{
+                  id
+                }
+              }
+            }
+          }
+        }
+        meta {
+          time
+        }
+      }
+    }
+  }
+}
+"""
+
+
+TEST_CASE_CANCELED = """
+{
+  testCaseCanceled(%s) {
+    edges {
+      node {
+        links {
+          ... on TestCaseExecution {
+            testCaseTriggered {
+              data {
+                testCase{
+                  id
+                }
+              }
+            }
+          }
+        }
+        meta {
+          time
         }
       }
     }

--- a/cli/src/etos_client/events/collector.py
+++ b/cli/src/etos_client/events/collector.py
@@ -22,7 +22,6 @@ from .events import (
     TestSuite,
     SubSuite,
     Environment,
-    Announcement,
     Artifact,
 )
 
@@ -131,20 +130,6 @@ class Collector:  # pylint:disable=too-few-public-methods
         activity.finished = finished
         return activity
 
-    def __announcements(
-        self, tercc_id: UUID, activity_id: Optional[UUID]
-    ) -> list[Announcement]:
-        """Collect announcements for an ETOS test run."""
-        ids = [str(tercc_id)]
-        if activity_id is not None:
-            ids.append(str(activity_id))
-        announcements = []
-        for announcement in self.event_repository.request_announcements(
-            self.etos_library, ids
-        ):
-            announcements.append(Announcement.parse_obj(announcement["data"]))
-        return announcements
-
     def __artifacts(self, sub_suites: list[SubSuite]) -> list[Artifact]:
         """Collect artifacts from ETOS."""
         artifacts = []
@@ -178,7 +163,6 @@ class Collector:  # pylint:disable=too-few-public-methods
         self.__events.tercc = self.__tercc(tercc_id)
         if self.__events.tercc is None:
             return self.__events
-        self.__events.announcements = self.__announcements(tercc_id, activity_id)
 
         self.__events.activity = self.__activity(tercc_id)
         if self.__events.activity.triggered is None:

--- a/cli/src/etos_client/events/events.py
+++ b/cli/src/etos_client/events/events.py
@@ -33,13 +33,6 @@ class Environment(BaseModel):
     uri: Optional[str]
 
 
-class Announcement(BaseModel):
-    """ETOS announcements."""
-
-    heading: str
-    body: str
-
-
 class Artifact(BaseModel):
     """ETOS artifact."""
 
@@ -70,5 +63,4 @@ class Events(BaseModel):
     tercc: Optional[dict]
     main_suites: list[TestSuite] = []
     environments: list[Environment] = []
-    announcements: list[Announcement] = []
     artifacts: list[Artifact] = []

--- a/cli/src/etos_client/events/events.py
+++ b/cli/src/etos_client/events/events.py
@@ -56,6 +56,13 @@ class TestSuite(BaseModel):
     sub_suites: list[SubSuite] = []
 
 
+class TestCase(BaseModel):
+    """ETOS test case events."""
+
+    finished: Optional[dict]
+    canceled: Optional[dict]
+
+
 class Events(BaseModel):
     """ETOS events."""
 
@@ -64,3 +71,4 @@ class Events(BaseModel):
     main_suites: list[TestSuite] = []
     environments: list[Environment] = []
     artifacts: list[Artifact] = []
+    test_cases: list[TestCase] = []

--- a/cli/src/etos_client/start.py
+++ b/cli/src/etos_client/start.py
@@ -88,6 +88,9 @@ def wait(
         log_downloader.stop(clear_queue)
         log_downloader.join()
 
+    LOGGER.info(
+        "Downloaded a total of %d logs from test runners", len(log_downloader.downloads)
+    )
     LOGGER.info("Archiving reports.")
     shutil.make_archive(
         artifact_dir.joinpath("reports").relative_to(Path.cwd()), "zip", report_dir


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #148 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Changed the logging in ETOS client to be more user focused.
Set log downloading to debug so it is not shown by default.
Changed the keep-alive message from ETOS to be more useful.
Stop logging the announcement events from ETOS.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Nothing really. I wanted to add some more information, but I decided that we want to keep the output minimal until we get complaints that something is missing.

### Benefits
<!-- What benefits will be realized by the change? -->
Makes it a lot clearer what is going on in ETOS.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This change has some hard dependency to the SSE stream that we implemented in ETOS. If that one goes down, then the logging will not be as good.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
