### PR TITLE
Fix a potential deadlock

### DIFF
--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -75,11 +75,21 @@ class TestRun:
 
         self.__log_debug_information(etos.response)
         self.__last_log = time.time()
+        timer = None
         for _ in self.__log_until_eof(etos, end):
             events = self.__collect(etos)
             self.__status(events)
             self.__announce()
             self.__download(events)
+            if events.activity.finished and timer is None:
+                timer = time.time() + 300  # 5 minutes
+            if timer and time.time() >= timer:
+                self.logger.warning("ETOS finished, but did not shut down the log server.")
+                self.logger.warning(
+                    "Forcing a shut down to avoid hanging. Some data may be incorrect, "
+                    "such as the number of tests executed or the number of downloaded logs"
+                )
+                break
         self.__wait(etos, end)
         events = self.__collect(etos)
         self.__download(events)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
There's a risk that the ETOS client deadlocks should the SSE client not properly shut down when an ETOS test run is finished. This extra check will give the SSE client >5 minutes to shut down and, if it doesn't, will force shutdown of the loop.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I do believe that the change to our v1 protocol fixes/mitigates this problem, however there's still a small risk so I wanted to add it anyway.

### Benefits
<!-- What benefits will be realized by the change? -->
Reduces the number of deadlocks we get in the client.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
There could be a problem with the client exiting early, without getting all logs downloaded. I did give the client 5 minutes to finish, however, so that shouldn't be a real problem.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
