### PR TITLE
Adding an etcd cluster

### DIFF
--- a/manifests/etcd/kustomization.yaml
+++ b/manifests/etcd/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - service.yaml
+  - statefulset.yaml

--- a/manifests/etcd/service.yaml
+++ b/manifests/etcd/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-client
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/part-of: etos
+spec:
+  type: ClusterIP
+  ports:
+  - name: etcd-client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  selector:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/part-of: etos
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/part-of: etos
+spec:
+  clusterIP: None
+  ports:
+  - port: 2379
+    name: client
+  - port: 2380
+    name: peer
+  selector:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/part-of: etos

--- a/manifests/etcd/statefulset.yaml
+++ b/manifests/etcd/statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/part-of: etos
+spec:
+  serviceName: etcd
+  replicas: 3
+  template:
+    metadata:
+      name: etcd
+      labels:
+        app.kubernetes.io/name: etcd
+        app.kubernetes.io/part-of: etos
+    spec:
+      containers:
+      - name: etcd
+        image: quay.io/coreos/etcd:latest
+        ports:
+        - containerPort: 2379
+          name: client
+        - containerPort: 2380
+          name: peer
+        volumeMounts:
+        - name: data
+          mountPath: /var/run/etcd
+        command:
+          - /bin/sh
+          - -c
+          - |
+            PEERS="etcd-0=http://etcd-0.etcd:2380,etcd-1=http://etcd-1.etcd:2380,etcd-2=http://etcd-2.etcd:2380"
+            exec etcd --name ${HOSTNAME} \
+              --listen-peer-urls http://0.0.0.0:2380 \
+              --listen-client-urls http://0.0.0.0:2379 \
+              --advertise-client-urls http://${HOSTNAME}.etcd:2379 \
+              --initial-advertise-peer-urls http://${HOSTNAME}:2380 \
+              --initial-cluster-token etcd-cluster-1 \
+              --initial-cluster ${PEERS} \
+              --initial-cluster-state new \
+              --data-dir /var/run/etcd/default.etcd
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi

--- a/manifests/master/kustomization.yaml
+++ b/manifests/master/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - github.com/eiffel-community/etos-environment-provider//manifests/base
   - github.com/eiffel-community/etos-suite-runner//manifests/base
   - github.com/eiffel-community/etos-suite-starter//manifests/base
+
+components:
+  - ../etcd


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
We are looking into replacing redis with etcd in ETOS. This change is in preparation for that. Making sure that we have an ETCD cluster deployed that we can play around with.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I could have skipped adding etcd by default and just having a cluster deployed when I play around with etcd. The problem with that however is that we may end up where we are with redis. I.e. we do not deploy redis with ETOS at the moment.
This change would also make it easier for us to actually start using etcd on the side, verifying in a real environment that it works as we expect.

### Benefits
<!-- What benefits will be realized by the change? -->
This change will allow us to start playing around with and verify etcd as a database replacement in ETOS.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Adding this now, when we are not sure we want to use it (even if we are quite sure) adds, potentially, unnecessary pods into our users kubernetes clusters.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
