### PR TITLE
Add pydantic dependency

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -17,3 +17,4 @@
 #
 etos_lib==4.0.0
 docopt~=0.6
+pydantic~=2.6

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -31,6 +31,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
     etos_lib==4.0.0
     docopt~=0.6
+    pydantic~=2.6
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.4


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
Add missing dependency to pydantic which causes etosctl failure at start.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com