### PR TITLE
Fix pydantic validation for pydantic 2.6.x

### DIFF
--- a/cli/src/etos_client/events/events.py
+++ b/cli/src/etos_client/events/events.py
@@ -21,16 +21,16 @@ from pydantic import BaseModel
 class Activity(BaseModel):
     """ETOS activity events."""
 
-    triggered: Optional[dict]
-    canceled: Optional[dict]
-    finished: Optional[dict]
+    triggered: Optional[dict] = None
+    canceled: Optional[dict] = None
+    finished: Optional[dict] = None
 
 
 class Environment(BaseModel):
     """ETOS environment events."""
 
     name: str
-    uri: Optional[str]
+    uri: Optional[str] = None
 
 
 class Artifact(BaseModel):
@@ -44,30 +44,30 @@ class Artifact(BaseModel):
 class SubSuite(BaseModel):
     """ETOS sub suite events."""
 
-    started: Optional[dict]
-    finished: Optional[dict]
+    started: Optional[dict] = None
+    finished: Optional[dict] = None
 
 
 class TestSuite(BaseModel):
     """ETOS main suite events."""
 
-    started: Optional[dict]
-    finished: Optional[dict]
+    started: Optional[dict] = None
+    finished: Optional[dict] = None
     sub_suites: list[SubSuite] = []
 
 
 class TestCase(BaseModel):
     """ETOS test case events."""
 
-    finished: Optional[dict]
-    canceled: Optional[dict]
+    finished: Optional[dict] = None
+    canceled: Optional[dict] = None
 
 
 class Events(BaseModel):
     """ETOS events."""
 
     activity: Activity = Activity()
-    tercc: Optional[dict]
+    tercc: Optional[dict] = None
     main_suites: list[TestSuite] = []
     environments: list[Environment] = []
     artifacts: list[Artifact] = []


### PR DESCRIPTION
### Applicable Issues

- [pydantic validation errors when starting a testrun](https://github.com/eiffel-community/etos/issues/214)

### Description of the Change

Optional fields need to be given default values in order for the pydantic validation to work properly.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com