### PR TITLE
Attempt to reduce the number of ER requests

### DIFF
--- a/cli/src/etos_client/announcer/announcer.py
+++ b/cli/src/etos_client/announcer/announcer.py
@@ -86,6 +86,6 @@ class Announcer:  # pylint:disable=too-few-public-methods
             self.logger.info("Waiting for sub suites to start.")
             return
 
-        self.logger.info(self.__build_announcement(events))
+        # self.logger.info(self.__build_announcement(events))
         if logs:
             self.logger.info("Downloaded a total of %d logs from test runners", len(logs))

--- a/cli/src/etos_client/announcer/announcer.py
+++ b/cli/src/etos_client/announcer/announcer.py
@@ -86,6 +86,5 @@ class Announcer:  # pylint:disable=too-few-public-methods
             self.logger.info("Waiting for sub suites to start.")
             return
 
-        # self.logger.info(self.__build_announcement(events))
         if logs:
             self.logger.info("Downloaded a total of %d logs from test runners", len(logs))

--- a/cli/src/etos_client/events/collector.py
+++ b/cli/src/etos_client/events/collector.py
@@ -140,9 +140,8 @@ class Collector:  # pylint:disable=too-few-public-methods
                     )
         return artifacts
 
-    def collect(self, tercc_id: UUID) -> Events:
-        """Collect events from ETOS."""
-        activity_id = None
+    def collect_activity(self, tercc_id: UUID) -> Events:
+        """Collect activity events from ETOS."""
         self.__events.tercc = self.__tercc(tercc_id)
         if self.__events.tercc is None:
             return self.__events
@@ -150,6 +149,14 @@ class Collector:  # pylint:disable=too-few-public-methods
         self.__events.activity = self.__activity(tercc_id)
         if self.__events.activity.triggered is None:
             return self.__events
+        return self.__events
+
+    def collect(self, tercc_id: UUID) -> Events:
+        """Collect events from ETOS."""
+        if self.__events.activity.triggered is None:
+            events = self.collect_activity(tercc_id)
+            if events.activity.triggered is None:
+                return self.__events
         activity_id = UUID(self.__events.activity.triggered["meta"]["id"], version=4)
         self.__events.main_suites = self.__main_test_suites(activity_id)
         self.__events.artifacts.clear()

--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -118,7 +118,6 @@ class TestRun:
 
     def __announce(self, events: Events) -> None:
         """Announce current state of ETOS."""
-        # events = self.__collector.collect_test_case_events()
         self.__announcer.announce(events, self.__downloader.downloads)
 
     def __download(self, events: Events) -> None:

--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -36,11 +36,11 @@ class TestRun:
 
     logger = logging.getLogger(__name__)
     remote_logger = logging.getLogger("ETOS")
-    __last_log: int
-    # This log interval is not a guarantee as it depends on several
+
+    # The log interval is not a guarantee as it depends on several
     # factors, such as the SSE log listener which has its own Ping
     # interval.
-    log_interval = 30
+    log_interval = 120
 
     def __init__(self, collector: Collector, downloader: Downloader) -> None:
         """Initialize."""
@@ -74,13 +74,17 @@ class TestRun:
         end = time.time() + timeout
 
         self.__log_debug_information(etos.response)
-        self.__last_log = time.time()
+        last_log = time.time()
         timer = None
         for _ in self.__log_until_eof(etos, end):
-            events = self.__collect(etos)
-            self.__status(events)
-            self.__announce()
-            self.__download(events)
+            if last_log + self.log_interval <= time.time():
+                events = self.__collect(etos)
+                last_log = time.time()
+                self.__status(events)
+            else:
+                events = self.__collect(etos)
+                self.__announce(events)
+                self.__download(events)
             if events.activity.finished and timer is None:
                 timer = time.time() + 300  # 5 minutes
             if timer and time.time() >= timer:
@@ -93,31 +97,29 @@ class TestRun:
         self.__wait(etos, end)
         events = self.__collect(etos)
         self.__download(events)
-        self.__announce(force=True)
+        self.__announce(events)
         return events
 
     def __wait(self, etos: ETOS, timeout: int) -> None:
         """Wait for ETOS to finish its activity."""
-        events = self.__collect(etos)
+        events = self.__collector.collect_activity(etos.response.tercc)
         while not events.activity.finished:
             self.logger.info("Waiting for ETOS to finish")
             self.__status(events)
             time.sleep(5)
             if time.time() >= timeout:
                 raise TimeoutError("ETOS did not complete in 24 hours. Exiting")
-            events = self.__collect(etos)
+            events = self.__collector.collect_activity(etos.response.tercc)
 
     def __status(self, events: Events) -> None:
         """Check if ETOS test run has been canceled."""
         if events.activity.canceled:
             raise SystemExit(events.activity.canceled["data"]["reason"])
 
-    def __announce(self, force: bool = False) -> None:
+    def __announce(self, events: Events) -> None:
         """Announce current state of ETOS."""
-        if force or self.__last_log + self.log_interval <= time.time():
-            events = self.__collector.collect_test_case_events()
-            self.__announcer.announce(events, self.__downloader.downloads)
-            self.__last_log = time.time()
+        # events = self.__collector.collect_test_case_events()
+        self.__announcer.announce(events, self.__downloader.downloads)
 
     def __download(self, events: Events) -> None:
         """Download logs and artifacts."""

--- a/cli/src/etos_client/test_run/test_run.py
+++ b/cli/src/etos_client/test_run/test_run.py
@@ -77,14 +77,14 @@ class TestRun:
         last_log = time.time()
         timer = None
         for _ in self.__log_until_eof(etos, end):
-            if last_log + self.log_interval <= time.time():
-                events = self.__collect(etos)
-                last_log = time.time()
+            if last_log + self.log_interval >= time.time():
+                events = self.__collector.collect_activity(etos.response.tercc)
                 self.__status(events)
             else:
                 events = self.__collect(etos)
                 self.__announce(events)
                 self.__download(events)
+                last_log = time.time()
             if events.activity.finished and timer is None:
                 timer = time.time() + 300  # 5 minutes
             if timer and time.time() >= timer:


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
#238 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
ETOS is doing a lot of requests to the event repositories. This is not scalable at all and we need to reduce the amount of queries we are doing and start working on a better solution.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
We could go to the final solution right away, but that is quite a ways away and we should try to reduce the queries now.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
We will be missing some test case information with this change, this is just flavor and not necessary for an ETOS testrun.
There will also be a few logs that may come at weird times such as "waiting for test suite to start" when you can clearly see from the SSE logs that the suite has started. This should be fine in my opinion.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
