### PR TITLE
Limit max number of connections to log area

### DIFF
--- a/cli/src/etos_client/downloader/downloader.py
+++ b/cli/src/etos_client/downloader/downloader.py
@@ -195,7 +195,8 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
     def run(self) -> None:
         """Run the log downloader thread."""
         self.started = True
-        with ThreadPool() as pool:
+        # 10 is the default max number of connections in Python requests library
+        with ThreadPool(10) as pool:
             while True:
                 if self.__exit and not self.__clear_queue:
                     self.logger.warning("Forced to exit without clearing the queue.")


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/249

### Description of the Change
This change sets the max number of simultaneous connections to 10, which equals the default limit in the requests library.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com