### PR TITLE
Log the correct fail/error message

### DIFF
--- a/cli/src/etos_client/test_results/test_results.py
+++ b/cli/src/etos_client/test_results/test_results.py
@@ -57,12 +57,6 @@ class TestResults:
         """Build test results based on events retrieved."""
         if not self.__has_failed(test_suites):
             return True, "Test suite finished successfully."
-
-        failures = 0
-        sub_suites = 0
-        for test_suite in test_suites:
-            failures += self.__count_sub_suite_failures(test_suite.sub_suites)
-            sub_suites += len(test_suite.sub_suites)
         messages = self.__fail_messages(test_suites)
         if len(messages) == 1:
             return False, messages[0]
@@ -70,9 +64,7 @@ class TestResults:
             for message in messages[:-1]:
                 self.logger.error(message)
             return False, messages[-1]
-        if sub_suites == 0:
-            return False, "ETOS failed to start any test suites"
-        return False, f"{failures}/{sub_suites} test suites failed."
+        return False, f"Test case failures during test suite execution"
 
     def get_results(self, events: Events) -> tuple[Optional[bool], Optional[str]]:
         """Get results from an ETOS testrun."""


### PR DESCRIPTION
### Description of the Change

Since we no longer collect information/events on subsuites
the logic fo logging messages about failures in sub suites
was not workin properly. This resulted in incorrect error
message when a suite successfully executed but had test case
failures in it.

### Possible Drawbacks
Log message will be a tad less detailed in it's information (e.g no information about the number of sub suites)

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
