### PR TITLE
add readme field to pyproject.toml

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -5,6 +5,7 @@ requires = ["setuptools>=72", "wheel", "setuptools_scm[toml]>=8"]
 name = "etos_client"
 dynamic = ["version"]
 description = "Test suite execution client for ETOS."
+readme = "README.rst"
 authors = [{name = "Tobias Persson", email = "tobias.persson@axis.com"}]
 license = { text  = "Apache License, Version 2.0" }
 classifiers = [


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/255

### Description of the Change

This change adds a `readme` field to `pyproject.toml` of the etos Python package. This is intended to fix the failing Pypi publishing action.

Pypi is complaining about `long_description`, however it seems to have been replaced with `readme`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com