### PR TITLE
Fix incorrect fields in cli/pyproject.toml

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=72", "wheel", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "etos_client"
@@ -13,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License"
 ]
+requires-python = ">=3.9"
 dependencies = [
     "etos_lib==4.0.0",
     "docopt~=0.6",
@@ -22,40 +24,18 @@ dependencies = [
 [project.optional-dependencies]
 testing = ["pytest", "pytest-cov"]
 
+[project.scripts]
+etos_client =  "etos_client.__main__:run"
+etosctl = "etosctl.__main__:run"
+
 [project.urls]
 Documentation = "https://etos.readthedocs.io/"
 Homepage = "https://github.com/eiffel-community/etos"
 Repository = "https://github.com/eiffel-community/etos"
 
-[options]
-zip_safe = false
-include_package_data = true
-python_requires = ">=3.4"
-
-[options.packages.find]
-where = "src"
-exclude = ["tests"]
-
-[tool.setuptools.package-dir]
-"" = "src"
-
-[project.scripts]
-etos_client =  "etos_client.__main__:run"
-etosctl = "etosctl.__main__:run"
-
-[test]
-extras = true
-
-[tool.pytest.ini_options]
-addopts = "--cov etos_cleint --cov-report term-missing --verbose"
-norecursedirs = ["dist", "build", ".tox"]
-testpaths = ["tests"]
-
-[aliases]
-dists = "bdist_wheel"
-
-[bdist_wheel]
-universal = 1
+[tool.build]
+# Use this option if your package is pure-python
+universal = true
 
 [tool.build_sphinx]
 source_dir = "docs"
@@ -67,3 +47,11 @@ formats = "bdist_wheel"
 
 [tool.flake8]
 exclude = [".tox", "build", "dist", ".eggs", "docs/conf.py"]
+
+[tool.pytest.ini_options]
+addopts = "--cov etos_cleint --cov-report term-missing --verbose"
+norecursedirs = ["dist", "build", ".tox"]
+testpaths = ["tests"]
+
+[tool.setuptools.packages]
+find = { where = ["src"], exclude = ["tests"] }

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -39,4 +39,11 @@ def local_scheme(version) -> str:
 
 
 if __name__ == "__main__":
-    setup(use_scm_version={"root": "..", "relative_to": __file__, "local_scheme": local_scheme, "version_scheme": version_scheme})
+    setup(
+        use_scm_version={
+            "root": "..",
+            "relative_to": __file__,
+            "local_scheme": local_scheme,
+            "version_scheme": version_scheme,
+        }
+    )

--- a/cli/src/etos_client/etos/etos.py
+++ b/cli/src/etos_client/etos/etos.py
@@ -85,7 +85,9 @@ class ETOS:  # pylint:disable=too-few-public-methods
         """Trigger ETOS, retrying on non-client errors until successful."""
         # retry rules are set in the Http client
         if self.v1alpha:
-            response = self.__http.post(f"{self.cluster}/api/v1alpha/testrun", json=request_data.model_dump())
+            response = self.__http.post(
+                f"{self.cluster}/api/v1alpha/testrun", json=request_data.model_dump()
+            )
         else:
             response = self.__http.post(f"{self.cluster}/api/etos", json=request_data.model_dump())
         if self.__response_ok(response):

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -16,5 +16,6 @@ commands =
 [testenv:pydocstyle]
 deps =
     pydocstyle
+    tomli
 commands =
     pydocstyle src/etos_client


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/208

### Description of the Change
This change fixes several fields to `cli/pyproject.toml` that were incorrect since the migration from `setup.cfg` to `pyproject.toml`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com