### PR TITLE
Increase timeout for start request

### DIFF
--- a/cli/src/etos_client/etos/etos.py
+++ b/cli/src/etos_client/etos/etos.py
@@ -52,6 +52,7 @@ class ETOS:  # pylint:disable=too-few-public-methods
         # ping HTTP client with 5 sec timeout for each attempt:
         self.__http_ping = Http(retry=HTTP_RETRY_PARAMETERS, timeout=5)
         # greater HTTP timeout for other requests: connection and read timeout combined
+        # Limitation: the current HTTP client does not allow to set timeout per request.
         self.__http = Http(retry=HTTP_RETRY_PARAMETERS, timeout=120)
 
     def start(self, request_data: RequestSchema) -> Union[ResponseSchema, None]:

--- a/cli/src/etos_client/etos/etos.py
+++ b/cli/src/etos_client/etos/etos.py
@@ -89,10 +89,16 @@ class ETOS:  # pylint:disable=too-few-public-methods
         timeout = 120
         if self.v1alpha:
             response = self.__http.post(
-                f"{self.cluster}/api/v1alpha/testrun", json=request_data.model_dump(), timeout=timeout
+                f"{self.cluster}/api/v1alpha/testrun",
+                json=request_data.model_dump(),
+                timeout=timeout,
             )
         else:
-            response = self.__http.post(f"{self.cluster}/api/etos", json=request_data.model_dump(), timeout=timeout)
+            response = self.__http.post(
+                f"{self.cluster}/api/etos",
+                json=request_data.model_dump(),
+                timeout=timeout,
+            )
         if self.__response_ok(response):
             return ResponseSchema.from_response(response.json())
         self.logger.critical("Failed to trigger ETOS.")

--- a/cli/src/etos_client/etos/etos.py
+++ b/cli/src/etos_client/etos/etos.py
@@ -51,8 +51,8 @@ class ETOS:  # pylint:disable=too-few-public-methods
         self.v1alpha = v1alpha
         # ping HTTP client with 5 sec timeout for each attempt:
         self.__http_ping = Http(retry=HTTP_RETRY_PARAMETERS, timeout=5)
-        # greater HTTP timeout for other requests:
-        self.__http = Http(retry=HTTP_RETRY_PARAMETERS, timeout=10)
+        # greater HTTP timeout for other requests: connection and read timeout combined
+        self.__http = Http(retry=HTTP_RETRY_PARAMETERS, timeout=120)
 
     def start(self, request_data: RequestSchema) -> Union[ResponseSchema, None]:
         """Start ETOS."""


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/286

### Description of the Change

This change increases the HTTP timeout in the start request to 120 seconds to allow time for operations like testrunner validation done by ETOS API.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com