### PR TITLE
Generate environment provider job names

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry.nordix.org/eiffel/etos-controller
-  newTag: aa5f76a1
+  newName: docker-sandbox.se.axis.com/nemesis/etos/controller
+  newTag: e751456

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: docker-sandbox.se.axis.com/nemesis/etos/controller
-  newTag: e751456
+  newName: registry.nordix.org/eiffel/etos-controller
+  newTag: aa5f76a1

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -219,13 +219,14 @@ func (r EnvironmentRequestReconciler) environmentProviderJob(environmentrequest 
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"etos.eiffel-community.github.io/id":      environmentrequest.Spec.Identifier, // TODO: omitempty
+				"etos.eiffel-community.github.io/name":    environmentrequest.Name,
 				"etos.eiffel-community.github.io/cluster": cluster,
 				"app.kubernetes.io/name":                  "environment-provider",
 				"app.kubernetes.io/part-of":               "etos",
 			},
-			Annotations: make(map[string]string),
-			Name:        environmentrequest.Name,
-			Namespace:   environmentrequest.Namespace,
+			Annotations:  make(map[string]string),
+			GenerateName: "environment-provider-",
+			Namespace:    environmentrequest.Namespace,
 		},
 		Spec: batchv1.JobSpec{
 			TTLSecondsAfterFinished: &ttl,

--- a/internal/controller/jobs.go
+++ b/internal/controller/jobs.go
@@ -140,7 +140,7 @@ func terminationLog(ctx context.Context, c client.Reader, job *batchv1.Job) (*Re
 	pod := pods.Items[0]
 
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.Name == job.Name {
+		if status.Name == job.Name || status.Name == job.Labels["etos.eiffel-community.github.io/name"] {
 			if status.State.Terminated == nil {
 				return &Result{Conclusion: ConclusionFailed}, errors.New("could not read termination log from pod")
 			}


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/262
 
### Description of the Change

This change introduces unique environment provider job names generated by Kubernetes.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com