### PR TITLE
Generated environment provider jobs

### DIFF
--- a/internal/controller/environment_controller.go
+++ b/internal/controller/environment_controller.go
@@ -155,7 +155,7 @@ func (r *EnvironmentReconciler) reconcileReleaser(ctx context.Context, releasers
 	// Environment releaser failed, setting status.
 	if releasers.failed() {
 		releaser := releasers.failedJobs[0] // TODO: We should allow multiple releaser jobs in the future
-		result, err := terminationLog(ctx, r, releaser)
+		result, err := terminationLog(ctx, r, releaser, environment.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}
@@ -169,7 +169,7 @@ func (r *EnvironmentReconciler) reconcileReleaser(ctx context.Context, releasers
 	// Environment releaser successful, setting status.
 	if releasers.successful() {
 		releaser := releasers.successfulJobs[0] // TODO: We should allow multiple releaser jobs in the future
-		result, err := terminationLog(ctx, r, releaser)
+		result, err := terminationLog(ctx, r, releaser, environment.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -155,7 +155,7 @@ func (r *EnvironmentRequestReconciler) reconcileEnvironmentProvider(ctx context.
 	// Environment provider failed, setting status.
 	if providers.failed() {
 		environmentProvider := providers.failedJobs[0] // TODO: We should support multiple providers in the future
-		result, err := terminationLog(ctx, r, environmentProvider)
+		result, err := terminationLog(ctx, r, environmentProvider, environmentrequest.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}
@@ -169,7 +169,7 @@ func (r *EnvironmentRequestReconciler) reconcileEnvironmentProvider(ctx context.
 	// Environment provider successful, setting status.
 	if providers.successful() {
 		environmentProvider := providers.successfulJobs[0] // TODO: We should support multiple providers in the future
-		result, err := terminationLog(ctx, r, environmentProvider)
+		result, err := terminationLog(ctx, r, environmentProvider, environmentrequest.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}
@@ -223,9 +223,9 @@ func (r EnvironmentRequestReconciler) environmentProviderJob(environmentrequest 
 				"app.kubernetes.io/name":                  "environment-provider",
 				"app.kubernetes.io/part-of":               "etos",
 			},
-			Annotations: make(map[string]string),
-			Name:        environmentrequest.Name,
-			Namespace:   environmentrequest.Namespace,
+			Annotations:  make(map[string]string),
+			GenerateName: "environment-provider-", // unique names to allow multiple environment provider jobs
+			Namespace:    environmentrequest.Namespace,
 		},
 		Spec: batchv1.JobSpec{
 			TTLSecondsAfterFinished: &ttl,

--- a/internal/controller/jobs.go
+++ b/internal/controller/jobs.go
@@ -123,7 +123,7 @@ type Result struct {
 }
 
 // terminationLog reads the termination-log part of the ESR pod and returns it.
-func terminationLog(ctx context.Context, c client.Reader, job *batchv1.Job) (*Result, error) {
+func terminationLog(ctx context.Context, c client.Reader, job *batchv1.Job, containerName string) (*Result, error) {
 	logger := log.FromContext(ctx)
 	var pods corev1.PodList
 	if err := c.List(ctx, &pods, client.InNamespace(job.Namespace), client.MatchingLabels{"job-name": job.Name}); err != nil {
@@ -140,7 +140,7 @@ func terminationLog(ctx context.Context, c client.Reader, job *batchv1.Job) (*Re
 	pod := pods.Items[0]
 
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.Name == job.Name {
+		if status.Name == containerName {
 			if status.State.Terminated == nil {
 				return &Result{Conclusion: ConclusionFailed}, errors.New("could not read termination log from pod")
 			}

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -296,7 +296,7 @@ func (r *TestRunReconciler) reconcileSuiteRunner(ctx context.Context, suiteRunne
 	// Suite runners failed, setting status.
 	if suiteRunners.failed() {
 		suiteRunner := suiteRunners.failedJobs[0] // TODO
-		result, err := terminationLog(ctx, r, suiteRunner)
+		result, err := terminationLog(ctx, r, suiteRunner, testrun.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}
@@ -312,7 +312,7 @@ func (r *TestRunReconciler) reconcileSuiteRunner(ctx context.Context, suiteRunne
 	// Suite runners successful, setting status.
 	if suiteRunners.successful() {
 		suiteRunner := suiteRunners.successfulJobs[0] // TODO
-		result, err := terminationLog(ctx, r, suiteRunner)
+		result, err := terminationLog(ctx, r, suiteRunner, testrun.Name)
 		if err != nil {
 			result.Description = err.Error()
 		}


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/262

### Description of the Change
This change adds generated names for environment provider jobs and changes the logic for matching containers in terminationLog().

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com