### PR TITLE
add reconcile for suite runner role and role binding

### DIFF
--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -341,7 +341,7 @@ func (r *ETOSSuiteStarterDeployment) reconcileRolebinding(ctx context.Context, l
 		if !apierrors.IsNotFound(err) {
 			return rolebinding, err
 		}
-		logger.Info(fmt.Sprintf("Creating a new role binding for the suite starter: %s", roleName))
+		logger.Info("Creating a new role binding for the suite starter", "roleName", roleName)
 		if err := r.Create(ctx, target); err != nil {
 			return target, err
 		}

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -56,26 +56,31 @@ func NewETOSSuiteStarterDeployment(spec etosv1alpha1.ETOSSuiteStarter, scheme *r
 // Reconcile will reconcile the ETOS suite starter to its expected state.
 func (r *ETOSSuiteStarterDeployment) Reconcile(ctx context.Context, cluster *etosv1alpha1.Cluster) error {
 	var err error
-	name := fmt.Sprintf("%s-etos-suite-starter", cluster.Name)
-	logger := log.FromContext(ctx, "Reconciler", "ETOSSuiteStarter", "BaseName", name)
-	namespacedName := types.NamespacedName{Name: name, Namespace: cluster.Namespace}
-	_, err = r.reconcileSuiteRunnerServiceAccount(ctx, logger, namespacedName, cluster)
+	suiteStarterName := fmt.Sprintf("%s-etos-suite-starter", cluster.Name)
+	suiteRunnerName := fmt.Sprintf("%s-etos-suite-runner", cluster.Name)
+
+	logger := log.FromContext(ctx, "Reconciler", "ETOSSuiteStarter", "BaseName", suiteStarterName)
+
+	nsSuiteStarterName := types.NamespacedName{Name: suiteStarterName, Namespace: cluster.Namespace}
+	nsSuiteRunnerName := types.NamespacedName{Name: suiteRunnerName, Namespace: cluster.Namespace}
+
+	_, err = r.reconcileServiceAccount(ctx, logger, nsSuiteRunnerName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the Suite runner service account")
 		return err
 	}
 	// This secret is in use when running the TestRun controller. When the suite starter is removed, this MUST still be created.
-	secret, err := r.reconcileSuiteRunnerSecret(ctx, logger, namespacedName, cluster)
+	secret, err := r.reconcileSuiteRunnerSecret(ctx, logger, nsSuiteRunnerName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the Suite runner secret")
 		return err
 	}
-	cfg, err := r.reconcileConfig(ctx, logger, secret.ObjectMeta.Name, namespacedName, cluster)
+	cfg, err := r.reconcileConfig(ctx, logger, secret.ObjectMeta.Name, nsSuiteStarterName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the Suite starter config")
 		return err
 	}
-	template, err := r.reconcileTemplate(ctx, logger, namespacedName, cluster)
+	template, err := r.reconcileTemplate(ctx, logger, nsSuiteRunnerName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the Suite runner template")
 		return err
@@ -87,53 +92,73 @@ func (r *ETOSSuiteStarterDeployment) Reconcile(ctx context.Context, cluster *eto
 		suiteRunnerTemplateName = r.SuiteRunnerTemplateSecretName
 	}
 	logger.Info("Suite runner template", "suiteRunnerTemplateName", suiteRunnerTemplateName)
-	_, err = r.reconcileDeployment(ctx, logger, cfg.ObjectMeta.Name, suiteRunnerTemplateName, namespacedName, cluster)
+	_, err = r.reconcileDeployment(ctx, logger, cfg.ObjectMeta.Name, suiteRunnerTemplateName, nsSuiteStarterName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the deployment for the ETOS Suite Starter")
 		return err
 	}
-	_, err = r.reconcileSecret(ctx, logger, namespacedName, cluster)
+	_, err = r.reconcileSecret(ctx, logger, nsSuiteStarterName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the secret for the ETOS Suite Starter")
 		return err
 	}
-	_, err = r.reconcileRole(ctx, logger, namespacedName, cluster)
+	_, err = r.reconcileRole(ctx, logger, nsSuiteStarterName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the role for the ETOS Suite Starter")
 		return err
 	}
-	_, err = r.reconcileServiceAccount(ctx, logger, namespacedName, cluster)
+	_, err = r.reconcileServiceAccount(ctx, logger, nsSuiteStarterName, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the service account for the ETOS Suite Starter")
 		return err
 	}
-	_, err = r.reconcileRolebinding(ctx, logger, namespacedName, cluster)
+	_, err = r.reconcileRolebinding(ctx, logger, nsSuiteStarterName, "esr-handler", cluster)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile the role binding for the ETOS Suite Starter")
+		return err
+	}
+
+	_, err = r.reconcileSuiteRunnerRole(ctx, logger, nsSuiteRunnerName, cluster)
+	if err != nil {
+		logger.Error(err, "Failed to reconcile the Suite Runner role")
+		return err
+	}
+
+	_, err = r.reconcileServiceAccount(ctx, logger, nsSuiteRunnerName, cluster)
+	if err != nil {
+		logger.Error(err, "Failed to reconcile the Suite Runner service account")
+		return err
+	}
+
+	_, err = r.reconcileRolebinding(ctx, logger, nsSuiteRunnerName, "testrun-reader", cluster)
+	if err != nil {
+		logger.Error(err, "Failed to reconcile the Suite Runner role binding")
 		return err
 	}
 	return err
 }
 
-// reconcileSuiteRunnerServiceAccount will reconcile the ETOS SuiteStarter service account to its expected state.
-func (r *ETOSSuiteStarterDeployment) reconcileSuiteRunnerServiceAccount(ctx context.Context, logger logr.Logger, name types.NamespacedName, owner metav1.Object) (*corev1.ServiceAccount, error) {
-	target := r.serviceaccount(name)
+// reconcileSuiteRunnerRole will reconcile the ETOS SuiteStarter role to its expected state.
+func (r *ETOSSuiteStarterDeployment) reconcileSuiteRunnerRole(ctx context.Context, logger logr.Logger, name types.NamespacedName, owner metav1.Object) (*rbacv1.Role, error) {
+	labelName := name.Name
+	name.Name = fmt.Sprintf("%s:sa:testrun-reader", name.Name)
+
+	target := r.testReaderRole(name, labelName)
 	if err := ctrl.SetControllerReference(owner, target, r.Scheme); err != nil {
 		return target, err
 	}
 
-	serviceaccount := &corev1.ServiceAccount{}
-	if err := r.Get(ctx, name, serviceaccount); err != nil {
+	role := &rbacv1.Role{}
+	if err := r.Get(ctx, name, role); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return serviceaccount, err
+			return role, err
 		}
-		logger.Info("Creating a new service account for the suite runner")
 		if err := r.Create(ctx, target); err != nil {
 			return target, err
 		}
 		return target, nil
 	}
-	return target, r.Patch(ctx, target, client.StrategicMergeFrom(serviceaccount))
+	return target, r.Patch(ctx, target, client.StrategicMergeFrom(role))
 }
 
 // reconcileSuiteRunnerSecret will reconcile the ETOS suite runner secret to its expected state.
@@ -309,8 +334,8 @@ func (r *ETOSSuiteStarterDeployment) reconcileServiceAccount(ctx context.Context
 }
 
 // reconcileRolebinding will reconcile the ETOS SuiteStarter service account role binding to its expected state.
-func (r *ETOSSuiteStarterDeployment) reconcileRolebinding(ctx context.Context, logger logr.Logger, name types.NamespacedName, owner metav1.Object) (*rbacv1.RoleBinding, error) {
-	target := r.rolebinding(name)
+func (r *ETOSSuiteStarterDeployment) reconcileRolebinding(ctx context.Context, logger logr.Logger, name types.NamespacedName, roleName string, owner metav1.Object) (*rbacv1.RoleBinding, error) {
+	target := r.rolebinding(name, roleName)
 	if err := ctrl.SetControllerReference(owner, target, r.Scheme); err != nil {
 		return target, err
 	}
@@ -320,7 +345,7 @@ func (r *ETOSSuiteStarterDeployment) reconcileRolebinding(ctx context.Context, l
 		if !apierrors.IsNotFound(err) {
 			return rolebinding, err
 		}
-		logger.Info("Creating a new role binding for the suite starter")
+		logger.Info(fmt.Sprintf("Creating a new role binding for the suite starter: %s", roleName))
 		if err := r.Create(ctx, target); err != nil {
 			return target, err
 		}
@@ -440,6 +465,27 @@ func (r *ETOSSuiteStarterDeployment) role(name types.NamespacedName, labelName s
 	}
 }
 
+// testReader creates a role resource definition giving read permissions for testrun resource
+func (r *ETOSSuiteStarterDeployment) testReaderRole(name types.NamespacedName, labelName string) *rbacv1.Role {
+	meta := r.meta(types.NamespacedName{Name: labelName, Namespace: name.Namespace})
+	meta.Name = name.Name
+	meta.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	return &rbacv1.Role{
+		ObjectMeta: meta,
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"etos.eiffel-community.github.io"},
+				Resources: []string{
+					"testruns",
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
+		},
+	}
+}
+
 // serviceaccount creates a service account resource definition for the ETOS SuiteStarter.
 func (r *ETOSSuiteStarterDeployment) serviceaccount(name types.NamespacedName) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
@@ -448,13 +494,13 @@ func (r *ETOSSuiteStarterDeployment) serviceaccount(name types.NamespacedName) *
 }
 
 // rolebinding creates a rolebinding resource definition for the ETOS SuiteStarter.
-func (r *ETOSSuiteStarterDeployment) rolebinding(name types.NamespacedName) *rbacv1.RoleBinding {
+func (r *ETOSSuiteStarterDeployment) rolebinding(name types.NamespacedName, roleName string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: r.meta(name),
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     "Role",
-			Name:     fmt.Sprintf("%s:sa:esr-handler", name.Name),
+			Name:     fmt.Sprintf("%s:sa:%s", name.Name, roleName),
 		},
 		Subjects: []rbacv1.Subject{
 			{


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/300

### Description of the Change
This change adds reconciliation of Suite Runner service account, role and rolebinding.

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com