### PR TITLE
Properly set the service account name in ESR template

### DIFF
--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -187,9 +187,9 @@ func (r *ETOSSuiteStarterDeployment) reconcileConfig(ctx context.Context, logger
 }
 
 // reconcileTemplate will reconcile the ETOS SuiteRunner template to its expected state.
-func (r *ETOSSuiteStarterDeployment) reconcileTemplate(ctx context.Context, logger logr.Logger, name types.NamespacedName, owner metav1.Object) (*corev1.Secret, error) {
-	name = types.NamespacedName{Name: fmt.Sprintf("%s-template", name.Name), Namespace: name.Namespace}
-	target := r.suiteRunnerTemplate(name)
+func (r *ETOSSuiteStarterDeployment) reconcileTemplate(ctx context.Context, logger logr.Logger, saName types.NamespacedName, owner metav1.Object) (*corev1.Secret, error) {
+	name := types.NamespacedName{Name: fmt.Sprintf("%s-template", saName.Name), Namespace: saName.Namespace}
+	target := r.suiteRunnerTemplate(name, saName)
 	if err := ctrl.SetControllerReference(owner, target, r.Scheme); err != nil {
 		return target, err
 	}
@@ -532,7 +532,7 @@ func (r *ETOSSuiteStarterDeployment) container(name types.NamespacedName, secret
 }
 
 // suiteRunnerTemplate creates a secret resource for the ETOS SuiteStarter.
-func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(name types.NamespacedName) *corev1.Secret {
+func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.NamespacedName, saName types.NamespacedName) *corev1.Secret {
 	data := map[string][]byte{
 		"suite_runner_template.yaml": []byte(fmt.Sprintf(`
       apiVersion: batch/v1
@@ -631,10 +631,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(name types.NamespacedNa
                 mountPath: /kubexit
             restartPolicy: Never
         backoffLimit: 0
-    `, name.Name)),
+    `, saName.Name)),
 	}
 	return &corev1.Secret{
-		ObjectMeta: r.meta(name),
+		ObjectMeta: r.meta(templateName),
 		Data:       data,
 	}
 }


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
The service account was created using the suite runner name and the template for the ESR used that name plus the suffix "-template" to name the ESR template. That same name was then also used as the SA for the ESR, a SA that does not exist because it was not created with the suffix.
The fix here is to grab two names for the template, one is the name of the template and the other is the name of service account.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
