### PR TITLE
Remove TERCC from testrun controller

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -351,11 +350,7 @@ func (r *TestRunReconciler) reconcileSuiteRunner(ctx context.Context, suiteRunne
 	}
 	// No suite runners, create suite runner
 	if suiteRunners.empty() {
-		tercc, err := json.Marshal(testrun.Spec.Suites)
-		if err != nil {
-			return err
-		}
-		suiteRunner := r.suiteRunnerJob(tercc, testrun)
+		suiteRunner := r.suiteRunnerJob(testrun)
 		if err := ctrl.SetControllerReference(testrun, suiteRunner, r.Scheme); err != nil {
 			return err
 		}
@@ -462,7 +457,7 @@ func (r TestRunReconciler) environmentRequest(testrun *etosv1alpha1.TestRun, sui
 }
 
 // suiteRunnerJob is the job definition for an etos suite runner.
-func (r TestRunReconciler) suiteRunnerJob(tercc []byte, testrun *etosv1alpha1.TestRun) *batchv1.Job {
+func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv1.Job {
 	grace := int64(30)
 	backoff := int32(0)
 	return &batchv1.Job{
@@ -564,10 +559,6 @@ func (r TestRunReconciler) suiteRunnerJob(tercc []byte, testrun *etosv1alpha1.Te
 								},
 							},
 							Env: []corev1.EnvVar{
-								{
-									Name:  "TERCC",
-									Value: string(tercc),
-								},
 								{
 									Name:  "ARTIFACT",
 									Value: testrun.Spec.Artifact,


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

Now when ESR is able to retrieve testrun resources from Kubernetes directly we can remove the TERCC environment variable from the testrun controller. 

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: andrei.matveyeu@axis.com