### PR TITLE
Environment request: multiple provider jobs in status checks

### DIFF
--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -195,7 +195,6 @@ func (r *EnvironmentRequestReconciler) reconcileEnvironmentProvider(ctx context.
 			if result.Conclusion == ConclusionFailed {
 				if meta.SetStatusCondition(&environmentrequest.Status.Conditions, metav1.Condition{Type: StatusReady, Status: metav1.ConditionFalse, Reason: "Failed", Message: result.Description}) {
 					statusUpdated = true
-					//return r.Status().Update(ctx, environmentrequest)
 				}
 			}
 			if meta.SetStatusCondition(&environmentrequest.Status.Conditions, metav1.Condition{Type: StatusReady, Status: metav1.ConditionTrue, Reason: "Done", Message: result.Description}) {


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/264

### Description of the Change

This change allows multiple environment provider jobs during job status checks in `EnvironmentRequestReconciler`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com