### PR TITLE
testrun controller: remove unused labels

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -463,9 +463,6 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				// TODO: remove these two first ones
-				"id":                                 testrun.Spec.ID,
-				"app":                                "suite-runner",
 				"etos.eiffel-community.github.io/id": testrun.Spec.ID,
 				"app.kubernetes.io/name":             "suite-runner",
 				"app.kubernetes.io/part-of":          "etos",


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/277

#### Related PR
- https://github.com/eiffel-community/etos-api/pull/97
- https://github.com/eiffel-community/etos-api/pull/98

### Description of the Change
This change removes the old unused labels `id` and `app` from the testrun controller.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com