### PR TITLE
Block environmentrequest deletion and propagate deletes

### DIFF
--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -18,7 +18,9 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -71,6 +74,27 @@ func (r *EnvironmentRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		logger.Error(err, "failed to get environmentrequest")
 		return ctrl.Result{}, err
+	}
+	if environmentrequest.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Add a finalizer if there is none, the finalizer will stop the Kubernetes garbage collector
+		// from removing the EnvironmentRequest until the finalizer is removed. Removal of the finalizer
+		// is done below, if DeletionTimestamp is set and all Environments related to this EnvironmentRequest
+		// are removed.
+		if !controllerutil.ContainsFinalizer(environmentrequest, releaseFinalizer) {
+			controllerutil.AddFinalizer(environmentrequest, releaseFinalizer)
+			if err := r.Update(ctx, environmentrequest); err != nil {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+	} else {
+		// Environmentrequest is under deletion. Wait for environments to get deleted before finalizing.
+		if controllerutil.ContainsFinalizer(environmentrequest, releaseFinalizer) {
+			return r.reconcileDeletion(ctx, environmentrequest)
+		}
 	}
 	if environmentrequest.Status.CompletionTime != nil {
 		return ctrl.Result{}, nil
@@ -350,6 +374,58 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 		},
 	}
 	return envList, nil
+}
+
+// reconcileDeletion checks for active environments and deletes them, causing them to clean up, and then, when all environments
+// are deleted, this function will remove the finalizer on the environmentrequest and the environmentrequest will be removed.
+func (r EnvironmentRequestReconciler) reconcileDeletion(ctx context.Context, environmentrequest *etosv1alpha1.EnvironmentRequest) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	statusReady := meta.FindStatusCondition(environmentrequest.Status.Conditions, StatusReady)
+	if statusReady == nil {
+		statusReady = &metav1.Condition{Type: StatusReady, Status: metav1.ConditionFalse, Reason: "Unknown"}
+	}
+	logger.Info("Setting status message", "status", metav1.Condition{Type: statusReady.Type, Status: statusReady.Status, Reason: statusReady.Reason, Message: "Releasing environment"})
+	if meta.SetStatusCondition(&environmentrequest.Status.Conditions, metav1.Condition{Type: statusReady.Type, Status: statusReady.Status, Reason: statusReady.Reason, Message: "Releasing environment"}) {
+		if err := r.Status().Update(ctx, environmentrequest); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
+	var environments etosv1alpha1.EnvironmentList
+	logger := log.FromContext(ctx)
+	if err := r.List(ctx, &environments, client.InNamespace(environmentrequest.Namespace), client.MatchingLabels{"etos.eiffel-community.github.io/id": environmentrequest.Spec.Identifier}); err != nil {
+		logger.Error(err, fmt.Sprintf("could not list pods for job %s", environmentrequest.Name))
+		return ctrl.Result{Requeue: true}, err
+	}
+	var allErr error
+	var err error
+	for _, environment := range environments.Items {
+		// Environment is not deleted.
+		if environment.ObjectMeta.DeletionTimestamp.IsZero() {
+			if err = r.Delete(ctx, &environment); err != nil {
+				logger.Error(err, "failed to delete environment", "environment", environment)
+				allErr = errors.Join(allErr, err)
+			}
+		}
+	}
+	if allErr != nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if len(environments.Items) != 0 {
+		logger.Info("Waiting for Environments to get deleted", "stillAlive", len(environments.Items))
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	controllerutil.RemoveFinalizer(environmentrequest, releaseFinalizer)
+	if err := r.Update(ctx, environmentrequest); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // environmentProviderJob is the job definition for an etos environment provider.

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -395,7 +395,6 @@ func (r EnvironmentRequestReconciler) reconcileDeletion(ctx context.Context, env
 		}
 	}
 	var environments etosv1alpha1.EnvironmentList
-	logger := log.FromContext(ctx)
 	if err := r.List(ctx, &environments, client.InNamespace(environmentrequest.Namespace), client.MatchingLabels{"etos.eiffel-community.github.io/id": environmentrequest.Spec.Identifier}); err != nil {
 		logger.Error(err, fmt.Sprintf("could not list pods for job %s", environmentrequest.Name))
 		return ctrl.Result{Requeue: true}, err

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -90,11 +90,9 @@ func (r *EnvironmentRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 			return ctrl.Result{}, nil
 		}
-	} else {
+	} else if controllerutil.ContainsFinalizer(environmentrequest, releaseFinalizer) {
 		// Environmentrequest is under deletion. Wait for environments to get deleted before finalizing.
-		if controllerutil.ContainsFinalizer(environmentrequest, releaseFinalizer) {
-			return r.reconcileDeletion(ctx, environmentrequest)
-		}
+		return r.reconcileDeletion(ctx, environmentrequest)
 	}
 	if environmentrequest.Status.CompletionTime != nil {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
fixes: #362 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
When an environment request gets deleted, delete all environments connected to it and wait for them to be deleted before getting removed from Kubernetes. This will ensure that deletions of environment requests always propagate to the environments. Before this only deletion of testruns would, sometimes, propagate to environments.
This also fixes another issue in that the environment controller has a dependency to the environment request but it does not always exist in Kubernetes due to not blocking its deletion.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
Nope

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
More objects will get stuck if an environment cannot be released but it's better than crashing.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
