### PR TITLE
Pass parent activity to ETOS API if added

### DIFF
--- a/cli/src/etos_client/etos/v0/schema/request.py
+++ b/cli/src/etos_client/etos/v0/schema/request.py
@@ -26,6 +26,7 @@ class RequestSchema(BaseModel):
 
     artifact_id: Optional[str]
     artifact_identity: Optional[str]
+    parent_activity: Optional[str]
     test_suite_url: str
     dataset: Optional[Union[dict, list]] = {}
     execution_space_provider: Optional[str] = "default"
@@ -38,6 +39,7 @@ class RequestSchema(BaseModel):
         return RequestSchema(
             artifact_id=args["--identity"],
             artifact_identity=args["--identity"],
+            parent_activity=args["--parent-activity"] or None,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
             execution_space_provider=args["--execution-space-provider"] or "default",

--- a/cli/src/etos_client/etos/v0/subcommands/start.py
+++ b/cli/src/etos_client/etos/v0/subcommands/start.py
@@ -20,6 +20,7 @@ import os
 import logging
 import json
 from json import JSONDecodeError
+from typing import Optional
 import warnings
 
 from etos_client.types.result import Conclusion, Verdict
@@ -40,7 +41,7 @@ class Start(SubCommand):
         -h, --help                                                Show this help message and exit
         -i IDENTITY, --identity IDENTITY                          Artifact created identity purl or ID to execute test suite on.
         -s TEST_SUITE, --test-suite TEST_SUITE                    Test suite execute. Either URL or name.
-        -p PARENT_ACTIVITY, --parent-activity PARENT_ACTIVITY     Activity for the TERCC to link to as a parent activity.
+        -p PARENT_ACTIVITY, --parent-activity PARENT_ACTIVITY     Activity for the TERCC to link to as the cause of the test execution.
         --no-tty                                                  This parameter is no longer in use.
         -w WORKSPACE, --workspace WORKSPACE                       Which workspace to do all the work in.
         -a ARTIFACT_DIR, --artifact-dir ARTIFACT_DIR              Where test artifacts should be stored. Relative to workspace.
@@ -59,16 +60,17 @@ class Start(SubCommand):
         name="start", description="Start an ETOSv0 testrun.", version="v0"
     )
 
-    def activity_triggered(self, argv: list[str]):
+    def activity_triggered(self, argv: list[str]) -> Optional[str]:
         """Get an activity triggered event ID from environment or arguments."""
         if ("-p" not in argv and "--parent-activity" not in argv) and os.getenv(
             "EIFFEL_ACTIVITY_TRIGGERED"
         ) is not None:
             try:
                 actt = json.loads(os.getenv("EIFFEL_ACTIVITY_TRIGGERED", ""))
-                argv.extend(["--parent-activity", actt["meta"]["id"]])
+                return actt["meta"]["id"]
             except (JSONDecodeError, IndexError):
                 self.logger.warning("Could not load EIFFEL_ACTIVITY_TRIGGERED from environment due it not being formatted JSON")
+        return None
 
     def parse_args(self, argv: list[str]) -> dict:
         """Parse arguments for etosctl testrun start."""
@@ -78,7 +80,9 @@ class Start(SubCommand):
             "TEST_SUITE"
         ) is not None:
             argv.extend(["--test-suite", os.getenv("TEST_SUITE", "")])
-        self.activity_triggered(argv)
+        parent_activity_id = self.activity_triggered(argv)
+        if parent_activity_id is not None:
+            argv.extend(["--parent-activity", parent_activity_id])
         return super().parse_args(argv)
 
     def run(self, args: dict) -> None:


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
fixes: #221 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Pass an activity triggered event ID to the ETOS API if supplied.
Will take an input parameter or read ActT from an environment variable.
This change only affects etos v0 since v1alpha does not yet support causal events #341 

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
