### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -12,8 +12,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Log into registry
-        run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Clean workspace
         run: |
           rm -r dist | true

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-and-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -23,7 +23,7 @@ jobs:
           rm -r dist | true
       - name: Generate manifest file
         run: |
-          IMAGE_ID=registry.nordix.org/eiffel/etos-controller
+          IMAGE_ID=ghcr.io/eiffel-community/etos-controller
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= registry.nordix.org/eiffel/etos-controller:latest
+IMG ?= ghcr.io/eiffel-community/etos-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Installation Steps
 
 ::
 
-    helm repo add Eiffel ghcr.io/eiffel-community
+    helm repo add Eiffel registry.nordix.org/eiffel
 
 2. Then simply install ETOS using Helm
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Installation Steps
 
 ::
 
-    helm repo add Eiffel registry.nordix.org/eiffel
+    helm repo add Eiffel ghcr.io/eiffel-community
 
 2. Then simply install ETOS using Helm
 

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -40,13 +40,13 @@ type EventRepository struct {
 
 	// We do not build the GraphQL API automatically nor publish it remotely.
 	// This will need to be provided to work.
-	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/eiffel-graphql-api:latest"}
+	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/eiffel-graphql-api:latest"}
 	// +optional
 	API Image `json:"api"`
 
 	// We do not build the GraphQL API automatically nor publish it remotely.
 	// This will need to be provided to work.
-	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/eiffel-graphql-storage:latest"}
+	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/eiffel-graphql-storage:latest"}
 	// +optional
 	Storage Image `json:"storage"`
 	// +kubebuilder:default="etos"

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -40,13 +40,13 @@ type EventRepository struct {
 
 	// We do not build the GraphQL API automatically nor publish it remotely.
 	// This will need to be provided to work.
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/eiffel-graphql-api:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/eiffel-graphql-api:latest"}
 	// +optional
 	API Image `json:"api"`
 
 	// We do not build the GraphQL API automatically nor publish it remotely.
 	// This will need to be provided to work.
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/eiffel-graphql-storage:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/eiffel-graphql-storage:latest"}
 	// +optional
 	Storage Image `json:"storage"`
 	// +kubebuilder:default="etos"
@@ -223,25 +223,25 @@ type ETOSConfig struct {
 
 // ETOS describes the deployment of an ETOS cluster.
 type ETOS struct {
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-api:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-api:latest"}
 	// +optional
 	API ETOSAPI `json:"api"`
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-sse:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-sse:latest"}
 	// +optional
 	SSE ETOSSSE `json:"sse"`
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-log-area:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-log-area:latest"}
 	// +optional
 	LogArea ETOSLogArea `json:"logArea"`
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-suite-runner:latest", "logListener": {"image": "registry.nordix.org/eiffel/etos-log-listener:latest"}}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-suite-runner:latest", "logListener": {"image": "ghcr.io/eiffel-community/etos-log-listener:latest"}}
 	// +optional
 	SuiteRunner ETOSSuiteRunner `json:"suiteRunner"`
 	// +kubebuilder:default={"version": "latest"}
 	// +optional
 	TestRunner ETOSTestRunner `json:"testRunner"`
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-suite-starter:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-suite-starter:latest"}
 	// +optional
 	SuiteStarter ETOSSuiteStarter `json:"suiteStarter"`
-	// +kubebuilder:default={"image": "registry.nordix.org/eiffel/etos-environment-provider:latest"}
+	// +kubebuilder:default={"image": "ghcr.io/eiffel-community/etos-environment-provider:latest"}
 	// +optional
 	EnvironmentProvider ETOSEnvironmentProvider `json:"environmentProvider"`
 	Ingress             Ingress                 `json:"ingress,omitempty"`

--- a/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
@@ -73,7 +73,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: registry.nordix.org/eiffel/etos-api:latest
+                      image: ghcr.io/eiffel-community/etos-api:latest
                     description: ETOSAPI describes the deployment of the ETOS API.
                     properties:
                       executionSpaceProviderSecret:
@@ -206,7 +206,7 @@ spec:
                     type: object
                   environmentProvider:
                     default:
-                      image: registry.nordix.org/eiffel/etos-environment-provider:latest
+                      image: ghcr.io/eiffel-community/etos-environment-provider:latest
                     description: ETOSEnvironmentProvider describes the deployment
                       of an ETOS environment provider.
                     properties:
@@ -238,7 +238,7 @@ spec:
                     type: object
                   logArea:
                     default:
-                      image: registry.nordix.org/eiffel/etos-log-area:latest
+                      image: ghcr.io/eiffel-community/etos-log-area:latest
                     description: ETOSLogArea describes th deployment of an ETOS log
                       area API.
                     properties:
@@ -254,7 +254,7 @@ spec:
                     type: object
                   sse:
                     default:
-                      image: registry.nordix.org/eiffel/etos-sse:latest
+                      image: ghcr.io/eiffel-community/etos-sse:latest
                     description: ETOSSSE describes th deployment of an ETOS Server
                       Sent Events API.
                     properties:
@@ -270,9 +270,9 @@ spec:
                     type: object
                   suiteRunner:
                     default:
-                      image: registry.nordix.org/eiffel/etos-suite-runner:latest
+                      image: ghcr.io/eiffel-community/etos-suite-runner:latest
                       logListener:
-                        image: registry.nordix.org/eiffel/etos-log-listener:latest
+                        image: ghcr.io/eiffel-community/etos-log-listener:latest
                     description: ETOSSuiteRunner describes the deployment of an ETOS
                       suite runner.
                     properties:
@@ -309,7 +309,7 @@ spec:
                     type: object
                   suiteStarter:
                     default:
-                      image: registry.nordix.org/eiffel/etos-suite-starter:latest
+                      image: ghcr.io/eiffel-community/etos-suite-starter:latest
                     description: ETOSSuiteStarter describes the deployment of an ETOS
                       suite starter.
                     properties:
@@ -377,7 +377,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: registry.nordix.org/eiffel/eiffel-graphql-api:latest
+                      image: ghcr.io/eiffel-community/eiffel-graphql-api:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.
@@ -497,7 +497,7 @@ spec:
                     type: object
                   storage:
                     default:
-                      image: registry.nordix.org/eiffel/eiffel-graphql-storage:latest
+                      image: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.

--- a/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
@@ -73,7 +73,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: ghcr.io/eiffel-community/etos-api:latest
+                      image: registry.nordix.org/eiffel/etos-api:latest
                     description: ETOSAPI describes the deployment of the ETOS API.
                     properties:
                       executionSpaceProviderSecret:
@@ -377,7 +377,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: ghcr.io/eiffel-community/eiffel-graphql-api:latest
+                      image: registry.nordix.org/eiffel/eiffel-graphql-api:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.
@@ -497,7 +497,7 @@ spec:
                     type: object
                   storage:
                     default:
-                      image: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
+                      image: registry.nordix.org/eiffel/eiffel-graphql-storage:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry.nordix.org/eiffel/etos-controller
+  newName: ghcr.io/eiffel-community/etos-controller
   newTag: 5becd344

--- a/config/samples/etos_v1alpha1_cluster.yaml
+++ b/config/samples/etos_v1alpha1_cluster.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   etos:
     api:
-      image: "registry.nordix.org/eiffel/etos-api:672f982e"
+      image: "ghcr.io/eiffel-community/etos-api:672f982e"
     sse:
-      image: "registry.nordix.org/eiffel/etos-sse:672f982e"
+      image: "ghcr.io/eiffel-community/etos-sse:672f982e"
     logArea:
-      image: "registry.nordix.org/eiffel/etos-logarea:672f982e"
+      image: "ghcr.io/eiffel-community/etos-logarea:672f982e"
     ingress:
       enabled: true
   database:
@@ -26,8 +26,8 @@ spec:
       queueName: "etos.*.log"
   eventRepository:
     deploy: true
-    apiImage: registry.nordix.org/eiffel/eiffel-graphql-api:latest
-    storageImage: registry.nordix.org/eiffel/eiffel-graphql-storage:latest 
+    apiImage: ghcr.io/eiffel-community/eiffel-graphql-api:latest
+    storageImage: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
     mongo:
       deploy: true
     ingress:

--- a/config/samples/etos_v1alpha1_cluster.yaml
+++ b/config/samples/etos_v1alpha1_cluster.yaml
@@ -26,8 +26,8 @@ spec:
       queueName: "etos.*.log"
   eventRepository:
     deploy: true
-    apiImage: ghcr.io/eiffel-community/eiffel-graphql-api:latest
-    storageImage: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
+    apiImage: registry.nordix.org/eiffel/eiffel-graphql-api:latest
+    storageImage: registry.nordix.org/eiffel/eiffel-graphql-storage:latest 
     mongo:
       deploy: true
     ingress:

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -605,7 +605,7 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               - mountPath: /kubexit
                 name: kubexit
             - name: create-queue
-              image: registry.nordix.org/eiffel/etos-log-listener:4969c9b2
+              image: ghcr.io/eiffel-community/etos-log-listener:4969c9b2
               command: ["python", "-u", "-m", "create_queue"]
               envFrom:
               - secretRef:

--- a/manifests/controller/install.yaml
+++ b/manifests/controller/install.yaml
@@ -386,7 +386,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: ghcr.io/eiffel-community/eiffel-graphql-api:latest
+                      image: registry.nordix.org/eiffel/eiffel-graphql-api:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.
@@ -506,7 +506,7 @@ spec:
                     type: object
                   storage:
                     default:
-                      image: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
+                      image: registry.nordix.org/eiffel/eiffel-graphql-storage:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.

--- a/manifests/controller/install.yaml
+++ b/manifests/controller/install.yaml
@@ -82,7 +82,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: registry.nordix.org/eiffel/etos-api:latest
+                      image: ghcr.io/eiffel-community/etos-api:latest
                     description: ETOSAPI describes the deployment of the ETOS API.
                     properties:
                       executionSpaceProviderSecret:
@@ -215,7 +215,7 @@ spec:
                     type: object
                   environmentProvider:
                     default:
-                      image: registry.nordix.org/eiffel/etos-environment-provider:latest
+                      image: ghcr.io/eiffel-community/etos-environment-provider:latest
                     description: ETOSEnvironmentProvider describes the deployment
                       of an ETOS environment provider.
                     properties:
@@ -247,7 +247,7 @@ spec:
                     type: object
                   logArea:
                     default:
-                      image: registry.nordix.org/eiffel/etos-log-area:latest
+                      image: ghcr.io/eiffel-community/etos-log-area:latest
                     description: ETOSLogArea describes th deployment of an ETOS log
                       area API.
                     properties:
@@ -263,7 +263,7 @@ spec:
                     type: object
                   sse:
                     default:
-                      image: registry.nordix.org/eiffel/etos-sse:latest
+                      image: ghcr.io/eiffel-community/etos-sse:latest
                     description: ETOSSSE describes th deployment of an ETOS Server
                       Sent Events API.
                     properties:
@@ -279,9 +279,9 @@ spec:
                     type: object
                   suiteRunner:
                     default:
-                      image: registry.nordix.org/eiffel/etos-suite-runner:latest
+                      image: ghcr.io/eiffel-community/etos-suite-runner:latest
                       logListener:
-                        image: registry.nordix.org/eiffel/etos-log-listener:latest
+                        image: ghcr.io/eiffel-community/etos-log-listener:latest
                     description: ETOSSuiteRunner describes the deployment of an ETOS
                       suite runner.
                     properties:
@@ -318,7 +318,7 @@ spec:
                     type: object
                   suiteStarter:
                     default:
-                      image: registry.nordix.org/eiffel/etos-suite-starter:latest
+                      image: ghcr.io/eiffel-community/etos-suite-starter:latest
                     description: ETOSSuiteStarter describes the deployment of an ETOS
                       suite starter.
                     properties:
@@ -386,7 +386,7 @@ spec:
                 properties:
                   api:
                     default:
-                      image: registry.nordix.org/eiffel/eiffel-graphql-api:latest
+                      image: ghcr.io/eiffel-community/eiffel-graphql-api:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.
@@ -506,7 +506,7 @@ spec:
                     type: object
                   storage:
                     default:
-                      image: registry.nordix.org/eiffel/eiffel-graphql-storage:latest
+                      image: ghcr.io/eiffel-community/eiffel-graphql-storage:latest
                     description: |-
                       We do not build the GraphQL API automatically nor publish it remotely.
                       This will need to be provided to work.
@@ -3250,7 +3250,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: registry.nordix.org/eiffel/etos-controller:5becd344
+        image: ghcr.io/eiffel-community/etos-controller:5becd344
         livenessProbe:
           httpGet:
             path: /healthz

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: etos
 build:
   artifacts:
-    - image: registry.nordix.org/eiffel/etos-controller
+    - image: ghcr.io/eiffel-community/etos-controller
       docker:
         dockerfile: Dockerfile
       hooks:


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This pull request changes all docker image references from `nordix.org/eiffel` to `ghcr.io/eiffel-community`.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com