### PR TITLE
Fix docker push permissions issue in generate-manifest.yml

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -36,7 +36,8 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=$(echo ${{ github.sha }} | cut -c1-8)
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          make docker-build docker-push split-installer IMG=$IMAGE_ID:$VERSION
+          make docker-build split-installer IMG=$IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
           mkdir -p manifests/controller
           cp dist/* manifests/controller/
       - name: Commit changes

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 20250130_ghcr_migration_fix # TODO: restore
   workflow_dispatch:
 
 permissions:
@@ -27,7 +28,7 @@ jobs:
           rm -r dist | true
       - name: Generate manifest file
         run: |
-          IMAGE_ID=ghcr.io/eiffel-community/etos-controller
+          IMAGE_ID=ghcr.io/andmat900/etos-controller # TODO: restore
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
@@ -37,18 +38,20 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           make docker-build split-installer IMG=$IMAGE_ID:$VERSION
-      - name: Push Docker image
-        if: github.ref == 'refs/heads/main'
-        run: |
           docker push $IMAGE_ID:$VERSION
+      - name: Push Docker image
+        if: github.ref == 'refs/heads/20250130_ghcr_migration_fix' # TODO: restore
+        run: |
+          echo 123 # TODO: fix docker push
       - name: Copy manifest files
         run: |
           mkdir -p manifests/controller
           cp dist/* manifests/controller/
-      - name: Commit changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add .
-          git commit -m "Update install manifest"
-          git push origin main
+      # TODO: restore
+      # - name: Commit changes
+      #   run: |
+      #     git config --global user.name 'github-actions[bot]'
+      #     git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      #     git add .
+      #     git commit -m "Update install manifest"
+      #     git push origin main

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -1,7 +1,8 @@
 name: Generate Manifest File
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -37,9 +37,12 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           make docker-build split-installer IMG=$IMAGE_ID:$VERSION
-          if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
-            docker push $IMAGE_ID:$VERSION
-          fi
+      - name: Push Docker image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker push $IMAGE_ID:$VERSION
+      - name: Copy manifest files
+        run: |
           mkdir -p manifests/controller
           cp dist/* manifests/controller/
       - name: Commit changes

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -1,8 +1,7 @@
 name: Generate Manifest File
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
   workflow_dispatch:
@@ -38,7 +37,9 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           make docker-build split-installer IMG=$IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
+            docker push $IMAGE_ID:$VERSION
+          fi
           mkdir -p manifests/controller
           cp dist/* manifests/controller/
       - name: Commit changes


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

This change replaces `docker-push` command from `Makefile` with explicit call to `docker push` in `generate-manifest.yaml`. The `docker-push`  in `Makefile` seems incompatible with `ghcr.io` login step, likely because they run with different shells/environment variables, so that credentials aren't shared.

Also, `docker push` is done only after the PR is merged, not on every push.

Error example:
https://github.com/eiffel-community/etos/actions/runs/13052056614/job/36414378632

The change makes the `docker push` call in the same way as in other ETOS repos such as `etos-api`, e. g.:
https://github.com/eiffel-community/etos-api/blob/380153ddd50aeeb32df2faaf2b700c702de50a9c/.github/workflows/build-push.yml#L175


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com