### PR TITLE
Remove redis from the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,6 @@ Here is an example of a standard ETOS configuration file that should get most co
       username: rabbit_user
       password: rabbit_password
 
-    # This is the configuration that should match your redis deployment
-    # ETOS uses redis for internal communication and data storage
-    databaseHost: redis.redis.svc.cluster.local
-    databasePort: "26379"
-    redis:
-      password: my_redis_password
-
 
 Contribute
 ==========

--- a/source/getting_started/step-by-step.rst
+++ b/source/getting_started/step-by-step.rst
@@ -23,7 +23,6 @@ For this reason we have created a checklist in order to keep track of what needs
 * |checkbox| Set up an :ref:`execution_space` (Execute test runner containers)
 * |checkbox| Set up a :ref:`log_area` (Storing logs after execution)
 * |checkbox| Deploy `MongoDB <https://www.mongodb.com/>`_ (Event storage DB)
-* |checkbox| Deploy `Redis Sentinel <https://redis.io/topics/sentinel>`_ (ETOS internal communications)
 * |checkbox| Deploy `RabbitMQ <https://www.rabbitmq.com/>`_ (must be accessible outside of kubernetes as well)
 * |checkbox| Deploy `Eiffel GraphQL API <https://eiffel-graphql-api.readthedocs.io/en/latest/readme.html#>`_
 


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/354

### Description of the Change
This change updates the documentation by removing redis mentions since it has been replaced by etcd which is installed as a part of ETOS.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com