### PR TITLE
fix KeyError when optional CLI args are omitted

### DIFF
--- a/cli/src/etos_client/etos/v0/schema/request.py
+++ b/cli/src/etos_client/etos/v0/schema/request.py
@@ -36,20 +36,15 @@ class RequestSchema(BaseModel):
     @classmethod
     def from_args(cls, args: dict) -> "RequestSchema":
         """Create a RequestSchema from an argument list from argparse."""
-        parent_activity = args["--parent-activity"] if "--parent-activity" in args else None
-        execution_space_provider = args["--execution-space-provider"] if "--execution-space-provider" in args else "default"
-        iut_provider = args["--iut-provider"] if "--iut-provider" in args else "default"
-        log_area_provider = args["--log-area-provider"] if "--log-area-provider" in args else "default"
-
         return RequestSchema(
             artifact_id=args["--identity"],
             artifact_identity=args["--identity"],
-            parent_activity=parent_activity,
+            parent_activity=args["--parent-activity"] or None,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
-            execution_space_provider=execution_space_provider,
-            iut_provider=iut_provider,
-            log_area_provider=log_area_provider,
+            execution_space_provider=args["--execution-space-provider"] or "default",
+            iut_provider=args["--iut-provider"] or "default",
+            log_area_provider=args["--log-area-provider"] or "default",
         )
 
     @field_validator("artifact_identity")

--- a/cli/src/etos_client/etos/v0/schema/request.py
+++ b/cli/src/etos_client/etos/v0/schema/request.py
@@ -36,15 +36,20 @@ class RequestSchema(BaseModel):
     @classmethod
     def from_args(cls, args: dict) -> "RequestSchema":
         """Create a RequestSchema from an argument list from argparse."""
+        parent_activity = args["--parent-activity"] if "--parent-activity" in args else None
+        execution_space_provider = args["--execution-space-provider"] if "--execution-space-provider" in args else "default"
+        iut_provider = args["--iut-provider"] if "--iut-provider" in args else "default"
+        log_area_provider = args["--log-area-provider"] if "--log-area-provider" in args else "default"
+
         return RequestSchema(
             artifact_id=args["--identity"],
             artifact_identity=args["--identity"],
-            parent_activity=args["--parent-activity"] or None,
+            parent_activity=parent_activity,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
-            execution_space_provider=args["--execution-space-provider"] or "default",
-            iut_provider=args["--iut-provider"] or "default",
-            log_area_provider=args["--log-area-provider"] or "default",
+            execution_space_provider=execution_space_provider,
+            iut_provider=iut_provider,
+            log_area_provider=log_area_provider,
         )
 
     @field_validator("artifact_identity")

--- a/cli/src/etos_client/etos/v1alpha/etos.py
+++ b/cli/src/etos_client/etos/v1alpha/etos.py
@@ -35,8 +35,8 @@ from etos_client.etos.v0.events.collector import Collector
 from etos_client.etos.v0.test_results import TestResults
 from etos_client.etos.v0.event_repository import graphql
 from etos_client.etos.v0.test_run import TestRun
-from etos_client.etos.v0.schema.response import ResponseSchema
-from etos_client.etos.v0.schema.request import RequestSchema
+from etos_client.etos.v1alpha.schema.response import ResponseSchema
+from etos_client.etos.v1alpha.schema.request import RequestSchema
 
 
 # Max total time for a ping request including delays with backoff factor 0.5 will be:

--- a/cli/src/etos_client/etos/v1alpha/schema/__init__.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOSv0 schemas."""

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ETOS v0 request schema."""
+"""ETOS v1 request schema."""
 import json
 from uuid import UUID
 
@@ -22,11 +22,10 @@ from pydantic import BaseModel, ValidationInfo, field_validator
 
 
 class RequestSchema(BaseModel):
-    """Schema for ETOSv0 API requests."""
+    """Schema for ETOSv1 API requests."""
 
     artifact_id: Optional[str]
     artifact_identity: Optional[str]
-    parent_activity: Optional[str]
     test_suite_url: str
     dataset: Optional[Union[dict, list]] = {}
     execution_space_provider: Optional[str] = "default"
@@ -39,7 +38,6 @@ class RequestSchema(BaseModel):
         return RequestSchema(
             artifact_id=args["--identity"],
             artifact_identity=args["--identity"],
-            parent_activity=args["--parent-activity"] or None,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
             execution_space_provider=args["--execution-space-provider"] or "default",

--- a/cli/src/etos_client/etos/v1alpha/schema/response.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/response.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ETOS v0 response schema."""
+"""ETOS v1 response schema."""
 from uuid import UUID
 from pydantic import BaseModel
 


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/359
 
### Description of the Change

The change modifies the `from_args` method to handle missing optional arguments more robustly by using conditional expressions to set default values. This ensures that the `RequestSchema` is created with appropriate default values when these arguments are not provided.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
