### PR TITLE
Set requests/limits for Suite Runner initContainers

### DIFF
--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -632,6 +632,11 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               imagePullPolicy: Always
               command: ['/kubexit/kubexit']
               args: ['python', '-u', '-m', 'etos_suite_runner']
+              resources:
+                requests:
+                  memory: "150Mi"
+                limits:
+                  memory: "300Mi"
               envFrom:
               - secretRef:
                   name: {etos_configmap}
@@ -660,6 +665,11 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               imagePullPolicy: Always
               command: ['/kubexit/kubexit']
               args: ['python', '-u', '-m', 'log_listener']
+              resources:
+                requests:
+                  memory: "128Mi"
+                limits:
+                  memory: "256Mi"
               envFrom:
               - secretRef:
                   name: {etos_configmap}

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -601,12 +601,22 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
             - name: kubexit
               image: karlkfi/kubexit:latest
               command: ["cp", "/bin/kubexit", "/kubexit/kubexit"]
+              resources:
+                requests:
+                  memory: "32Mi"
+                limits:
+                  memory: "64Mi"
               volumeMounts:
               - mountPath: /kubexit
                 name: kubexit
             - name: create-queue
               image: ghcr.io/eiffel-community/etos-log-listener:4969c9b2
               command: ["python", "-u", "-m", "create_queue"]
+              resources:
+                requests:
+                  memory: "128Mi"
+                limits:
+                  memory: "256Mi"
               envFrom:
               - secretRef:
                   name: {etos_configmap}


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

This change sets requests and limits for containers in the Runner template. This should increase scalability in environments where Kubernetes has high default memory allocation unless requests/limits are explicitly set.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com