### PR TITLE
testrun controller: remove hostname assumption for etcd

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -440,6 +440,16 @@ func (r TestRunReconciler) environmentRequest(cluster *etosv1alpha1.Cluster, tes
 		etosMessageBus.Host = fmt.Sprintf("%s-%s", cluster.Name, etosMessageBus.Host)
 	}
 
+	databaseHost := cluster.Spec.Database.Etcd.Host
+	if databaseHost == "" {
+		databaseHost = "etcd-client"
+	}
+
+	databasePort := cluster.Spec.Database.Etcd.Port
+	if databasePort == "" {
+		databasePort = "2379"
+	}
+
 	return &etosv1alpha1.EnvironmentRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -485,8 +495,8 @@ func (r TestRunReconciler) environmentRequest(cluster *etosv1alpha1.Cluster, tes
 				EncryptionKey:                       cluster.Spec.ETOS.Config.EncryptionKey,
 				RoutingKeyTag:                       cluster.Spec.ETOS.Config.RoutingKeyTag,
 				GraphQlServer:                       eventRepository,
-				EtcdHost:                            fmt.Sprintf("%s-etcd", cluster.Name),
-				EtcdPort:                            cluster.Spec.Database.Etcd.Port,
+				EtcdHost:                            databaseHost,
+				EtcdPort:                            databasePort,
 				EventDataTimeout:                    cluster.Spec.ETOS.Config.EventDataTimeout,
 				WaitForTimeout:                      cluster.Spec.ETOS.Config.EnvironmentTimeout,
 				EnvironmentProviderEventDataTimeout: cluster.Spec.ETOS.Config.EventDataTimeout,


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/372

### Description of the Change
This change removes the assumption about etcd hostname from the testrun controller. 

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com