### PR TITLE
pass missing variables to environment provider job

### DIFF
--- a/api/v1alpha1/environmentrequest_types.go
+++ b/api/v1alpha1/environmentrequest_types.go
@@ -53,7 +53,6 @@ type EnvironmentProviderJobConfig struct {
 	EncryptionKey     Var      `json:"encryptionKeySecretRef"`
 	EtcdHost          string   `json:"etcdHost"`
 	EtcdPort          string   `json:"etcdPort"`
-	EventDataTimeout  string   `json:"eventDataTimeout"`
 	GraphQlServer     string   `json:"graphQlServer"`
 	RoutingKeyTag     string   `json:"routingKeyTag"`
 	WaitForTimeout    string   `json:"waitForTimeout"`

--- a/config/crd/bases/etos.eiffel-community.github.io_environmentrequests.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_environmentrequests.yaml
@@ -317,8 +317,6 @@ spec:
                         default: /
                         type: string
                     type: object
-                  eventDataTimeout:
-                    type: string
                   graphQlServer:
                     type: string
                   routingKeyTag:
@@ -339,7 +337,6 @@ spec:
                 - etcdPort
                 - etosApi
                 - etosMessageBus
-                - eventDataTimeout
                 - graphQlServer
                 - routingKeyTag
                 - testRunnerVersion

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -282,6 +282,18 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 			Value: environmentrequest.Spec.Config.EtcdPort,
 		},
 		{
+			Name:  "ETOS_WAIT_FOR_IUT_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
+			Name:  "ETOS_WAIT_FOR_EXECUTION_SPACE_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
+			Name:  "ETOS_WAIT_FOR_LOG_AREA_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
 			// Optional when environmentrequest is not issued by testrun, i. e. created separately.
 			// When the environment request is issued by a testrun, this variable is propagated
 			// further from environment provider to test runner.

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -256,15 +255,7 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 	if err != nil {
 		return nil, err
 	}
-	dev := "false"
-	if os.Getenv("DEV") != "" {
-		dev = os.Getenv("DEV")
-	}
 	envList := []corev1.EnvVar{
-		{
-			Name:  "DEV",
-			Value: dev,
-		},
 		{
 			Name:  "REQUEST",
 			Value: environmentrequest.Name,
@@ -293,8 +284,13 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 			Name:  "ETOS_EVENT_DATA_TIMEOUT",
 			Value: environmentrequest.Spec.Config.EnvironmentProviderEventDataTimeout,
 		},
+		// Duplicate wait timeout variables will be possible to remove when this issue is solved: https://github.com/eiffel-community/etos/issues/304
 		{
 			Name:  "ETOS_WAIT_FOR_IUT_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
+			Name:  "ENVIRONMENT_PROVIDER_WAIT_FOR_IUT_TIMEOUT",
 			Value: environmentrequest.Spec.Config.WaitForTimeout,
 		},
 		{
@@ -302,7 +298,15 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 			Value: environmentrequest.Spec.Config.WaitForTimeout,
 		},
 		{
+			Name:  "ENVIRONMENT_PROVIDER_WAIT_FOR_EXECUTION_SPACE_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
 			Name:  "ETOS_WAIT_FOR_LOG_AREA_TIMEOUT",
+			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
+			Name:  "ENVIRONMENT_PROVIDER_WAIT_FOR_LOG_AREA_TIMEOUT",
 			Value: environmentrequest.Spec.Config.WaitForTimeout,
 		},
 		{

--- a/internal/controller/environmentrequest_controller.go
+++ b/internal/controller/environmentrequest_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -255,8 +256,15 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 	if err != nil {
 		return nil, err
 	}
-
+	dev := "false"
+	if os.Getenv("DEV") != "" {
+		dev = os.Getenv("DEV")
+	}
 	envList := []corev1.EnvVar{
+		{
+			Name:  "DEV",
+			Value: dev,
+		},
 		{
 			Name:  "REQUEST",
 			Value: environmentrequest.Name,
@@ -282,6 +290,10 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 			Value: environmentrequest.Spec.Config.EtcdPort,
 		},
 		{
+			Name:  "ETOS_EVENT_DATA_TIMEOUT",
+			Value: environmentrequest.Spec.Config.EnvironmentProviderEventDataTimeout,
+		},
+		{
 			Name:  "ETOS_WAIT_FOR_IUT_TIMEOUT",
 			Value: environmentrequest.Spec.Config.WaitForTimeout,
 		},
@@ -292,6 +304,10 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 		{
 			Name:  "ETOS_WAIT_FOR_LOG_AREA_TIMEOUT",
 			Value: environmentrequest.Spec.Config.WaitForTimeout,
+		},
+		{
+			Name:  "TEST_SUITE_TIMEOUT",
+			Value: environmentrequest.Spec.Config.EnvironmentProviderTestSuiteTimeout,
 		},
 		{
 			// Optional when environmentrequest is not issued by testrun, i. e. created separately.
@@ -330,6 +346,10 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 			Name:  "RABBITMQ_PASSWORD",
 			Value: string(eiffelRabbitMQPassword),
 		},
+		{
+			Name:  "RABBITMQ_ROUTING_KEY",
+			Value: environmentrequest.Spec.Config.RoutingKeyTag,
+		},
 
 		// ETOS Message Bus variables
 		{
@@ -359,6 +379,10 @@ func (r EnvironmentRequestReconciler) envVarListFrom(ctx context.Context, enviro
 		{
 			Name:  "ETOS_RABBITMQ_PASSWORD",
 			Value: string(etosRabbitMQPassword),
+		},
+		{
+			Name:  "ETOS_ROUTING_KEY_TAG",
+			Value: environmentrequest.Spec.Config.RoutingKeyTag,
 		},
 	}
 	return envList, nil

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -500,7 +500,6 @@ func (r TestRunReconciler) environmentRequest(cluster *etosv1alpha1.Cluster, tes
 				GraphQlServer:                       eventRepository,
 				EtcdHost:                            databaseHost,
 				EtcdPort:                            databasePort,
-				EventDataTimeout:                    cluster.Spec.ETOS.Config.EventDataTimeout,
 				WaitForTimeout:                      cluster.Spec.ETOS.Config.EnvironmentTimeout,
 				EnvironmentProviderEventDataTimeout: cluster.Spec.ETOS.Config.EventDataTimeout,
 				EnvironmentProviderImage:            cluster.Spec.ETOS.EnvironmentProvider.Image.Image,


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/374

### Description of the Change
This change makes sure all environment variables are passed from `EnvironmentProviderJobConfig` to the environment provider job.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com