### PR TITLE
Set limits on all containers in ESR

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -557,6 +557,16 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Name:    "kubexit",
 							Image:   "karlkfi/kubexit:latest",
 							Command: []string{"cp", "/bin/kubexit", "/kubexit/kubexit"},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kubexit",
@@ -569,6 +579,16 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Image:           testrun.Spec.LogListener.Image.Image,
 							ImagePullPolicy: testrun.Spec.LogListener.ImagePullPolicy,
 							Command:         []string{"python", "-u", "-m", "create_queue"},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -604,8 +604,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "32Mi"
+                  cpu: "100m"
                 limits:
                   memory: "64Mi"
+                  cpu: "250m"
               volumeMounts:
               - mountPath: /kubexit
                 name: kubexit
@@ -615,8 +617,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "128Mi"
+                  cpu: "100m"
                 limits:
                   memory: "256Mi"
+                  cpu: "250m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}
@@ -635,8 +639,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "150Mi"
+                  cpu: "100m"
                 limits:
                   memory: "300Mi"
+                  cpu: "250m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}
@@ -668,8 +674,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "128Mi"
+                  cpu: "100m"
                 limits:
                   memory: "256Mi"
+                  cpu: "250m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}


### PR DESCRIPTION

<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Also add CPU limits and requests in the suite runner template

I probably added too high limits for the initContainers, but since the pod will have its real limit and requests set to the highest request we will always get the LogListener container + the ESR container anyways because it's higher than the initContainers.
More on how Kubernetes calculates resources can be found [here](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resource-sharing-within-containers)

When Kubernetes support for [Pod resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-2) is generally available we should move over to use those.


### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
