### PR TITLE
Adjust suite-runner CPU requests and limits

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -561,11 +561,11 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("32Mi"),
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("25m"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -583,11 +583,11 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("256Mi"),
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("128Mi"),
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("25m"),
 								},
 							},
 							EnvFrom: []corev1.EnvFromSource{
@@ -617,7 +617,7 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("256Mi"),
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("200m"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -683,11 +683,11 @@ func (r TestRunReconciler) suiteRunnerJob(testrun *etosv1alpha1.TestRun) *batchv
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("256Mi"),
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("128Mi"),
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("25m"),
 								},
 							},
 							EnvFrom: []corev1.EnvFromSource{

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -604,10 +604,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "32Mi"
-                  cpu: "100m"
+                  cpu: "25m"
                 limits:
                   memory: "64Mi"
-                  cpu: "250m"
+                  cpu: "50m"
               volumeMounts:
               - mountPath: /kubexit
                 name: kubexit
@@ -617,10 +617,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "128Mi"
-                  cpu: "100m"
+                  cpu: "25m"
                 limits:
                   memory: "256Mi"
-                  cpu: "250m"
+                  cpu: "50m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}
@@ -642,7 +642,7 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
                   cpu: "100m"
                 limits:
                   memory: "300Mi"
-                  cpu: "250m"
+                  cpu: "200m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}
@@ -674,10 +674,10 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               resources:
                 requests:
                   memory: "128Mi"
-                  cpu: "100m"
+                  cpu: "25m"
                 limits:
                   memory: "256Mi"
-                  cpu: "250m"
+                  cpu: "50m"
               envFrom:
               - secretRef:
                   name: {etos_configmap}


### PR DESCRIPTION
### Applicable Issues
- Fixes: https://github.com/eiffel-community/etos/issues/394

### Description of the Change
This change adjusts Suite Runner containers' CPU requests and limits values based on data from several experiments.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com