### PR TITLE
Restart deployments and statefulsets if configurations have changed

### DIFF
--- a/internal/etos/api/api.go
+++ b/internal/etos/api/api.go
@@ -154,9 +154,10 @@ func (r *ETOSApiDeployment) reconcileDeployment(ctx context.Context, logger logr
 		}
 		return target, nil
 	} else if r.restartRequired {
-		deployment.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting deployment")
+		deployment.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
-	if equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
+	if !r.restartRequired && equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
 		return deployment, nil
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(deployment))

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -261,9 +261,10 @@ func (r *ETOSSuiteStarterDeployment) reconcileDeployment(ctx context.Context, lo
 		}
 		return target, nil
 	} else if r.restartRequired {
-		deployment.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting deployment")
+		deployment.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
-	if equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
+	if !r.restartRequired && equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
 		return deployment, nil
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(deployment))

--- a/internal/extras/eventrepository.go
+++ b/internal/extras/eventrepository.go
@@ -161,9 +161,10 @@ func (r *EventRepositoryDeployment) reconcileDeployment(ctx context.Context, log
 		logger.Info("Removing the deployment for EventRepository")
 		return nil, r.Delete(ctx, deployment)
 	} else if r.restartRequired {
-		deployment.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting deployment")
+		deployment.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
-	if equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
+	if !r.restartRequired && equality.Semantic.DeepDerivative(target.Spec, deployment.Spec) {
 		return deployment, nil
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(deployment))

--- a/internal/extras/messagebus.go
+++ b/internal/extras/messagebus.go
@@ -133,7 +133,8 @@ func (r *MessageBusDeployment) reconcileStatefulset(ctx context.Context, logger 
 		logger.Info("Removing the statefulset for MessageBus")
 		return nil, r.Delete(ctx, rabbitmq)
 	} else if r.restartRequired {
-		rabbitmq.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting statefulset")
+		rabbitmq.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(rabbitmq))
 }

--- a/internal/extras/mongodb.go
+++ b/internal/extras/mongodb.go
@@ -155,7 +155,8 @@ func (r *MongoDBDeployment) reconcileStatefulset(ctx context.Context, logger log
 		logger.Info("Removing the MongoDB statefulset")
 		return nil, r.Delete(ctx, mongodb)
 	} else if r.restartRequired {
-		mongodb.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting statefulset")
+		mongodb.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(mongodb))
 }

--- a/internal/extras/mongodb.go
+++ b/internal/extras/mongodb.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	etosv1alpha1 "github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/go-logr/logr"
@@ -41,14 +42,15 @@ var mongodbPort int32 = 27017
 type MongoDBDeployment struct {
 	etosv1alpha1.MongoDB
 	client.Client
-	Scheme     *runtime.Scheme
-	URL        url.URL
-	SecretName string
+	Scheme          *runtime.Scheme
+	URL             url.URL
+	SecretName      string
+	restartRequired bool
 }
 
 // NewMongoDBDeployment will create a new MongoDB reconciler.
 func NewMongoDBDeployment(spec etosv1alpha1.MongoDB, scheme *runtime.Scheme, client client.Client) *MongoDBDeployment {
-	return &MongoDBDeployment{spec, client, scheme, url.URL{}, ""}
+	return &MongoDBDeployment{spec, client, scheme, url.URL{}, "", false}
 }
 
 // Reconcile will reconcile MongoDB to its expected state.
@@ -112,6 +114,7 @@ func (r *MongoDBDeployment) reconcileSecret(ctx context.Context, logger logr.Log
 			return secret, err
 		}
 		if r.Deploy {
+			r.restartRequired = true
 			logger.Info("Secret not found. Creating")
 			if err := r.Create(ctx, target); err != nil {
 				return target, err
@@ -125,6 +128,7 @@ func (r *MongoDBDeployment) reconcileSecret(ctx context.Context, logger logr.Log
 	if equality.Semantic.DeepDerivative(target.Data, secret.Data) {
 		return secret, nil
 	}
+	r.restartRequired = true
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(secret))
 }
 
@@ -150,6 +154,8 @@ func (r *MongoDBDeployment) reconcileStatefulset(ctx context.Context, logger log
 	} else if !r.Deploy {
 		logger.Info("Removing the MongoDB statefulset")
 		return nil, r.Delete(ctx, mongodb)
+	} else if r.restartRequired {
+		mongodb.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(mongodb))
 }

--- a/internal/extras/rabbitmq.go
+++ b/internal/extras/rabbitmq.go
@@ -137,7 +137,8 @@ func (r *RabbitMQDeployment) reconcileStatefulset(ctx context.Context, logger lo
 		logger.Info("Removing the statefulset for RabbitMQ")
 		return nil, r.Delete(ctx, rabbitmq)
 	} else if r.restartRequired {
-		rabbitmq.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		logger.Info("Configuration(s) have changed, restarting statefulset")
+		rabbitmq.Spec.Template.Annotations["etos.eiffel-community.github.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	}
 	return target, r.Patch(ctx, target, client.StrategicMergeFrom(rabbitmq))
 }


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
By adding or updating an annotation to the spec Kubernetes will automatically recreate the deployments and statefulsets causing the pods to restart and get the new configurations. This way of doing it is the same way as kubectl rollout restart.

I've not been able to test this yet since my local environment is busted at the moment so this change may not work yet

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
None that I could think of.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
The one thing I thought of (and am going to test) is that we might get stuck in a reconcile loop. I don't know how or why but we've had these loops before and we need to verify that this change does not cause any.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
