### PR TITLE
add OpenTelemetry variables ETOSSuiteStarterConfig spec

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -145,6 +145,12 @@ type ETOSSuiteStarterConfig struct {
 	// +kubebuilder:default=""
 	// +optional
 	SidecarImage string `json:"sidecarImage,omitempty"`
+	// +kubebuilder:default=""
+	// +optional
+	OtelCollectorHost string `json:"otelCollectorHost,omitempty"`
+	// +kubebuilder:default=""
+	// +optional
+	ObservabilityConfigmapName string `json:"observabilityConfigmapName,omitempty"`
 }
 
 // ETOSSuiteStarter describes the deployment of an ETOS suite starter.

--- a/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
@@ -325,6 +325,12 @@ spec:
                           gracePeriod:
                             default: "300"
                             type: string
+                          observabilityConfigmapName:
+                            default: ""
+                            type: string
+                          otelCollectorHost:
+                            default: ""
+                            type: string
                           sidecarImage:
                             default: ""
                             type: string


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/411

### Description of the Change

This change extends ETOSSuiteStarterConfig with OpenTelemetry-related variables.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com