### PR TITLE
Update OpenTelemetry collector variable (#47)

### DIFF
--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -670,8 +670,8 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
                 value: /graveyard
               - name: OTEL_CONTEXT
                 value: {otel_context}
-              - name: OTEL_COLLECTOR_HOST
-                value: {otel_collector_host}
+			  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: {otel_exporter_otlp_endpoint}
               volumeMounts:
               - name: graveyard
                 mountPath: /graveyard


### PR DESCRIPTION
### Description of the Change
As a way to to uniform how we reference the OpenTelemetry Collector,
we are removing the variable OTEL_COLLECTOR_HOST and replacing it with
the standard OTEL_EXPORTER_OTLP_ENDPOINT.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
