### PR TITLE
downloader.py: read retries 10

### DIFF
--- a/cli/src/etos_client/shared/downloader.py
+++ b/cli/src/etos_client/shared/downloader.py
@@ -33,11 +33,12 @@ from requests.exceptions import HTTPError
 from etos_lib.lib.http import Http
 
 
+max_retries = 10  # With 1 as backoff_factor, the total wait time between retries will be 1023 seconds
 HTTP_RETRY_PARAMETERS = Retry(
     total=None,
-    read=0,
-    connect=10,  # With 1 as backoff_factor, will retry for 1023s
-    status=10,  # With 1 as backoff_factor, will retry for 1023s
+    read=max_retries,
+    connect=max_retries,
+    status=max_retries,
     backoff_factor=1,
     other=0,
     # 413, 429, 503 + 404 (for cases when the file is not uploaded immediately)


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/414

### Description of the Change
The read retries in the Downloader HTTP retry policy are increased. 

The code was introduced in this PR: https://github.com/eiffel-community/etos/pull/212/files. 

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com