### PR TITLE
etos_client: disable imports from etos_lib.messaging

### DIFF
--- a/cli/src/etos_client/etos/v1alpha/test_run/test_run.py
+++ b/cli/src/etos_client/etos/v1alpha/test_run/test_run.py
@@ -21,11 +21,23 @@ import time
 from typing import Union
 from pathlib import Path
 
-from etos_lib.messaging.events import Message, Report, Artifact, Shutdown
+#from etos_lib.messaging.events import Message, Report, Artifact, Shutdown  # import disabled due to: https://github.com/eiffel-community/etos/issues/417
 from etos_client.sse.v2alpha.client import SSEClient
 from etos_client.shared.downloader import Downloader, Downloadable
 from ..schema.response import ResponseSchema
 
+# dummy classes: remove when the etos_lib.messaging module is available: https://github.com/eiffel-community/etos/issues/417
+class Artifact:
+    pass
+
+class Message:
+    pass
+
+class Report:
+    pass
+
+class Shutdown:
+    pass
 
 class TestRun:
     """Track an ETOS test run and log relevant information."""

--- a/cli/src/etos_client/sse/v2alpha/client.py
+++ b/cli/src/etos_client/sse/v2alpha/client.py
@@ -24,7 +24,11 @@ from urllib3.exceptions import HTTPError, MaxRetryError
 from urllib3.poolmanager import PoolManager
 from urllib3.util import Retry
 
-from etos_lib.messaging.events import Shutdown, Event, parse
+#from etos_lib.messaging.events import Shutdown, Event, parse # import disabled due to: https://github.com/eiffel-community/etos/issues/417
+# dummy class: remove when the etos_lib.messaging module is available
+class Event:
+    pass
+
 
 CHUNK_SIZE = 500
 RETRIES = Retry(

--- a/cli/src/etos_debug/command.py
+++ b/cli/src/etos_debug/command.py
@@ -20,12 +20,25 @@ import sys
 import logging
 
 from etos_lib.lib.http import Http
-from etos_lib.messaging.events import Artifact, Message, Report, Shutdown
+#from etos_lib.messaging.events import Artifact, Message, Report, Shutdown  # import disabled due to: https://github.com/eiffel-community/etos/issues/417
 from urllib3.util import Retry
 from requests.exceptions import HTTPError
 from etosctl.command import Command
 from etosctl.models import CommandMeta
 from etos_client.sse.v2alpha.client import SSEClient
+
+# dummy classes: remove when the etos_lib.messaging module is available: https://github.com/eiffel-community/etos/issues/417
+class Artifact:
+    pass
+
+class Message:
+    pass
+
+class Report:
+    pass
+
+class Shutdown:
+    pass
 
 LOGGER = logging.getLogger(__name__)
 # Max total time for a ping request including delays with backoff factor 0.5 will be:


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/417

### Description of the Change
The change is a temporary workaround for the mentioned issue. It will be reverted when this etos-library change is integrated: https://github.com/eiffel-community/etos-library/pull/48

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com