### PR TITLE
Remove hard coded image name for log listener

### DIFF
--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -623,7 +623,7 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
               - mountPath: /kubexit
                 name: kubexit
             - name: create-queue
-              image: ghcr.io/eiffel-community/etos-log-listener:4969c9b2
+              image: {log_listener}
               command: ["python", "-u", "-m", "create_queue"]
               resources:
                 requests:


### PR DESCRIPTION
### Description of the Change
There was a reference to the log-listener image that was hard coded, replaced it with the proper
dynamic reference.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt<<fredrik.fristedt@axis.com>>
