### PR TITLE
setuptools_scm root path in cli/pyproject.toml

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -55,3 +55,6 @@ testpaths = ["tests"]
 
 [tool.setuptools.packages]
 find = { where = ["src"], exclude = ["tests"] }
+
+[tool.setuptools_scm]
+root = ".."


### PR DESCRIPTION
### Applicable Issues

Github CI fails to build the ETOS Client Python package:

https://github.com/eiffel-community/etos/actions/runs/16877339988/job/47804866576
```
   File "/tmp/build-env-bynyi_ut/lib/python3.9/site-packages/setuptools_scm/_integration/setuptools.py", line 123, in infer_version
    result.apply(dist)
  File "/tmp/build-env-bynyi_ut/lib/python3.9/site-packages/setuptools_scm/_integration/version_inference.py", line 48, in apply
    _version_missing(config)
  File "/tmp/build-env-bynyi_ut/lib/python3.9/site-packages/setuptools_scm/_get_version_impl.py", line 188, in _version_missing
    raise LookupError(error_msg)
LookupError: setuptools-scm was unable to detect version for /home/runner/work/etos/etos/cli.
```
### Description of the Change
This change adds `tool.setuptools_scm` section in ETOS Client's `pyproject.toml` to fix the Git version lookup problem.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
