### PR TITLE
read volatile etcd parameters from the cluster spec

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -103,6 +103,26 @@ type Etcd struct {
 	// +kubebuilder:default="2379"
 	// +optional
 	Port string `json:"port"`
+	// Parameter is ignored if Deploy is set to true.
+	// +kubebuilder:default="quay.io/coreos/etcd:v3.5.19"
+	// +optional
+	Image string `json:"image"`
+	// Parameter is ignored if Deploy is set to true.
+	// +kubebuilder:default="1024Mi"
+	// +optional
+	RequestsMemory string `json:"requestsMemory"`
+	// Parameter is ignored if Deploy is set to true.
+	// +kubebuilder:default="400m"
+	// +optional
+	RequestsCPU string `json:"requestsCPU"`
+	// Parameter is ignored if Deploy is set to true.
+	// +kubebuilder:default=1024*1024*1024
+	// +optional
+	LimitsMemory string `json:"limitsMemory"`
+	// Parameter is ignored if Deploy is set to true.
+	// +kubebuilder:default="400m"
+	// +optional
+	LimitsCPU string `json:"limitsCPU"`
 }
 
 // Database describes the deployment of a database for ETOS.

--- a/internal/etos/database.go
+++ b/internal/etos/database.go
@@ -261,15 +261,15 @@ func (r *ETCDDeployment) volume(name types.NamespacedName) corev1.Volume {
 func (r *ETCDDeployment) container(name types.NamespacedName) corev1.Container {
 	return corev1.Container{
 		Name:  "etcd",
-		Image: "quay.io/coreos/etcd:v3.5.19",
+		Image: r.Etcd.Image,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse(r.Etcd.LimitsMemory),
+				corev1.ResourceCPU:    resource.MustParse(r.Etcd.LimitsCPU),
 			},
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse(r.Etcd.RequestsMemory),
+				corev1.ResourceCPU:    resource.MustParse(r.Etcd.RequestsCPU),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This change adds the possibility to set volatile etcd parameters like image version, resource usage in the cluster spec.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com