### PR TITLE
apply ingress annotations from cluster spec

### DIFF
--- a/internal/etos/etos.go
+++ b/internal/etos/etos.go
@@ -335,12 +335,23 @@ func (r *ETOSDeployment) environmentProviderConfig(ctx context.Context, name typ
 
 // ingress creates an ingress resource definition for ETOS.
 func (r *ETOSDeployment) ingress(name types.NamespacedName) *networkingv1.Ingress {
+	meta := r.meta(name)
+
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+
+	for key, value := range r.Ingress.Annotations {
+		meta.Annotations[key] = value
+	}
+
 	ingress := &networkingv1.Ingress{
-		ObjectMeta: r.meta(name),
+		ObjectMeta: meta,
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{r.ingressRule(name)},
 		},
 	}
+
 	if r.Ingress.IngressClass != "" {
 		ingress.Spec.IngressClassName = &r.Ingress.IngressClass
 	}


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/429

### Description of the Change

This change modifies the controller code to apply ingress annotations from the cluster specification.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com