### PR TITLE
ETOS Client: basic identity validation in start subcommand

### DIFF
--- a/cli/src/etos_client/etos/v0/subcommands/start.py
+++ b/cli/src/etos_client/etos/v0/subcommands/start.py
@@ -26,6 +26,7 @@ import warnings
 from etos_client.types.result import Conclusion, Verdict
 from etos_client.etos.v0.etos import Etos
 from etos_client.sse.v1.client import SSEClient
+from etos_client.shared.validators import start_args_validator, CLIArgsValidationError
 
 from etosctl.command import SubCommand
 from etosctl.models import CommandMeta
@@ -87,6 +88,13 @@ class Start(SubCommand):
 
     def run(self, args: dict) -> None:
         """Start an ETOS testrun."""
+        # Validate arguments
+        try:
+            start_args_validator.validate_args(args)
+        except CLIArgsValidationError as e:
+            self.logger.error(str(e))
+            sys.exit(1)
+
         if args["--download-reports"]:
             warnings.warn(
                 "The '-d/--download-reports' parameter is deprecated",

--- a/cli/src/etos_client/etos/v1alpha/subcommands/start.py
+++ b/cli/src/etos_client/etos/v1alpha/subcommands/start.py
@@ -25,6 +25,7 @@ from etos_client.types.result import Conclusion, Verdict
 from etos_client.etos.v1alpha.etos import Etos
 from etos_client.sse.v2alpha.client import SSEClient as SSEV2AlphaClient
 from etos_client.sse.v1.client import SSEClient as SSEV1Client
+from etos_client.shared.validators import start_args_validator, CLIArgsValidationError
 
 from etosctl.command import SubCommand
 from etosctl.models import CommandMeta
@@ -69,6 +70,13 @@ class Start(SubCommand):
 
     def run(self, args: dict) -> None:
         """Start an ETOS testrun."""
+        # Validate arguments
+        try:
+            start_args_validator.validate_args(args)
+        except CLIArgsValidationError as e:
+            self.logger.error(str(e))
+            sys.exit(1)
+
         warnings.warn("This is an alpha version of ETOS! Don't expect it to work properly")
         self.logger.info("Running in cluster: %r", args["<cluster>"])
 

--- a/cli/src/etos_client/shared/validators.py
+++ b/cli/src/etos_client/shared/validators.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validators for CLI arguments of the start subcommand."""
+
+import uuid
+from typing import Any, Callable, Dict
+
+
+class CLIArgsValidationError(Exception):
+    """Exception raised when start subcommand argument validation fails."""
+    pass
+
+
+class IdentityValidator:
+    """Validator specifically for identity arguments (PURL or UUID)."""
+    
+    @staticmethod
+    def validate(value: str) -> None:
+        """Validate that a value is either a valid PURL or UUID."""
+        error_message = "Invalid identity: '{value}'. Expected: either a valid UUID or PURL (pkg:...)"
+
+        if not value or not isinstance(value, str):
+            raise CLIArgsValidationError(error_message.format(value=value))
+        
+        # Try to validate as UUID first
+        if IdentityValidator._is_valid_uuid(value):
+            return
+        
+        # Try to validate as PURL
+        if IdentityValidator._is_valid_purl(value):
+            return
+        
+        raise CLIArgsValidationError(error_message.format(value=value))
+    
+    @staticmethod
+    def _is_valid_uuid(value: str) -> bool:
+        """Check if a string is a valid UUID."""
+        try:
+            uuid.UUID(value)
+            return True
+        except (ValueError, AttributeError):
+            return False
+    
+    @staticmethod
+    def _is_valid_purl(value: str) -> bool:
+        """Check if a string is a valid Package URL (PURL)."""
+        # For now, just validate that it starts with "pkg:"
+        # This can be improved later with more comprehensive validation
+        return value.startswith("pkg:")
+
+
+class StartSubcommandArgumentValidator:
+    """Extensible argument validator for the start subcommand CLI arguments."""
+    
+    def __init__(self):
+        """Initialize the validator with built-in validation rules for start subcommand arguments."""
+        self._validators: Dict[str, Callable[[Any], None]] = {
+            'identity': IdentityValidator.validate,
+        }
+    
+    def add_validator(self, argument_name: str, validator_func: Callable[[Any], None]) -> None:
+        """Add a custom validator for a start subcommand argument."""
+        self._validators[argument_name] = validator_func
+    
+    def validate(self, argument_name: str, value: Any) -> None:
+        """Validate an argument value."""
+        if argument_name in self._validators:
+            self._validators[argument_name](value)
+    
+    def validate_args(self, args: Dict[str, Any], argument_mappings: Dict[str, str] = None) -> None:
+        """Validate multiple start subcommand arguments from a parsed arguments dictionary."""
+        if argument_mappings is None:
+            argument_mappings = {
+                '--identity': 'identity',
+                '-i': 'identity',
+            }
+        
+        for arg_key, validator_name in argument_mappings.items():
+            if arg_key in args and args[arg_key] is not None:
+                self.validate(validator_name, args[arg_key])
+
+
+start_args_validator = StartSubcommandArgumentValidator()


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/431

### Description of the Change
This change adds basic validation of the `--identity` value given to `etosctl`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
