### PR TITLE
Make SSE connection more robust during testrun start

### DIFF
--- a/cli/src/etos_client/sse/v1/client.py
+++ b/cli/src/etos_client/sse/v1/client.py
@@ -105,7 +105,7 @@ class SSEClient:
         return "v1"
 
     def __connect(self, stream_id: str, is_initial_connection=False) -> Iterable[bytes]:
-        """Handle standard connection for reconnections."""
+        """Handle connection for reconnections."""
         if is_initial_connection:
             # Use LogRetry with extended retries for initial connection
             retries = LogRetry(

--- a/cli/src/etos_client/sse/v2alpha/client.py
+++ b/cli/src/etos_client/sse/v2alpha/client.py
@@ -119,10 +119,7 @@ class SSEClient:
         return "v2alpha"
 
     def __connect(self, stream_id: str, apikey: str, is_initial_connection=False) -> Iterable[bytes]:
-        """Connect to an event-stream server with state-aware retry logic.
-
-        Sets the attribute `__release` which must be closed before exiting.
-        """
+        """Handle connection for reconnections."""
         if is_initial_connection:
             # Use LogRetry with extended retries for initial connection
             retries = LogRetry(


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/445

### Description of the Change

This change modifies the SSE connection behavior during test run start in order to:
- wait longer to prevent `etosctl` from terminating with `MaxRetriesExceeded` error before ESR pod was able to start
- provide logging feedback to the user during the connection

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com