### PR TITLE
fix publishing in the generate-manifest workflow

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -42,11 +42,11 @@ jobs:
           mkdir -p manifests/controller
           cp dist/* manifests/controller/
       - name: Push docker image
-        if: github.event.pull_request.merged == true
+        if: github.ref == 'refs/heads/main'
         run: |
           make docker-push IMG=$IMAGE_ID:$VERSION
       - name: Commit changes
-        if: github.event.pull_request.merged == true
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/464

### Description of the Change
The `generate-manifest` workflow will check the current branch name to determine if docker publishing shall be done.

### Alternate Designs

### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com