### PR TITLE
etosctl v1alpha: break from wait loop at SystemExit

### DIFF
--- a/cli/src/etos_client/etos/v1alpha/etos.py
+++ b/cli/src/etos_client/etos/v1alpha/etos.py
@@ -170,6 +170,7 @@ class Etos:
                     result = Result(
                         verdict=Verdict.INCONCLUSIVE, conclusion=Conclusion.FAILED, reason=str(exit)
                     )
+                    break
         finally:
             log_downloader.stop(clear_queue)
             log_downloader.join()


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This change corrects the handling of `SystemExit` condition in ETOS Client `v1alpha` handler.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com