### PR TITLE
generate-manifests.xml: add DEPLOY_KEY and skipping rule

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -51,5 +53,5 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
-          git commit -m "Update install manifest"
+          git commit -m "Update install manifest [skip ci]"
           git push origin main


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

This PR includes the following:
- adds DEPLOY_KEY to the `generate-manifests` part of the CI
- prevents infinite loops during manifest updates in the CI using `[skip ci]` rule in the commit message. This is according to the official documentation: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com