### PR TITLE
Update etos_lib to 5.1.6

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "etos_lib==5.1.4",
+    "etos_lib==5.1.6",
     "docopt~=0.6",
     "pydantic~=2.6",
 ]


### PR DESCRIPTION
This PR updates etos_lib from version 5.1.4 to 5.1.6 in the CLI component to align with other ETOS components.