### PR TITLE
Fix dependabot config name and strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,10 @@ updates:
     directory: "/cli"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase
     allow:
-      - dependency-name: "etos_lib"
+      - dependency-name: "etos-lib"
     groups:
       etos-lib:
         patterns:
-          - "etos_lib"
+          - "etos-lib"


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

Fixes two issues in the dependabot configuration that prevented it from creating update PRs for etos-lib:

1. **Name mismatch**: pip normalizes package names to use hyphens (`etos-lib`), but the config used underscores (`etos_lib`). This caused dependabot to skip the group because the allow rule did not match the normalized name.
2. **Wrong versioning strategy**: the default `widen_ranges` strategy cannot update `==` pins. Added `versioning-strategy: increase` so dependabot can bump `==5.1.6` to `==5.2.0`.

Error in dependabot run:
```
updater | 2026/02/18 12:33:11 WARN <job_1248235886> Please check your configuration as there are groups where no dependencies match:
- etos-lib

updater | 2026/02/18 12:33:11 WARN <job_1248235886> Skipping update group for 'etos-lib' as it does not match any allowed dependencies.
updater | 2026/02/18 12:33:12 INFO <job_1248235886> No update possible for etos-lib 5.1.6
```
https://github.com/eiffel-community/etos/actions/runs/22139870563/job/64001060484

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com