### PR TITLE
Set minimum Python version to 3.10 for etos client

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "etos_lib==5.1.6",
     "docopt~=0.6",


### PR DESCRIPTION
### Applicable Issues

N/A

### Description of the Change

Python 3.9 has reached end of life and is no longer relevant. This change updates the minimum required Python version for etos_client from 3.9 to 3.10 in pyproject.toml and updates the CI build workflow to use Python 3.10. Note that etos_lib (a dependency of etos_client) already requires Python >=3.10, so this aligns etos_client with its dependency.

### Alternate Designs

N/A

### Possible Drawbacks

Users still on Python 3.9 will no longer be able to install etos_client. This is expected since Python 3.9 is EOL.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com