### PR TITLE
Update environment release trace context

### DIFF
--- a/internal/controller/environment_controller.go
+++ b/internal/controller/environment_controller.go
@@ -312,11 +312,6 @@ func (r EnvironmentReconciler) releaseJob(ctx context.Context, obj client.Object
 			databaseHost = cluster.Spec.Database.Etcd.Host
 		}
 	}
-	traceparent, ok := environmentRequest.Annotations["etos.eiffel-community.github.io/traceparent"]
-	if !ok {
-		traceparent = ""
-	}
-
 	envList := []corev1.EnvVar{
 		{
 			Name:  "REQUEST",
@@ -331,8 +326,16 @@ func (r EnvironmentReconciler) releaseJob(ctx context.Context, obj client.Object
 			Value: databaseHost,
 		},
 		{
-			Name:  "OTEL_CONTEXT",
-			Value: traceparent,
+			Name:  "TRACEPARENT",
+			Value: environmentRequest.Annotations["etos.eiffel-community.github.io/traceparent"],
+		},
+		{
+			Name:  "BAGGAGE",
+			Value: environmentRequest.Annotations["etos.eiffel-community.github.io/baggage"],
+		},
+		{
+			Name:  "TRACESTATE",
+			Value: environmentRequest.Annotations["etos.eiffel-community.github.io/tracestate"],
 		},
 	}
 	if cluster != nil && cluster.Spec.OpenTelemetry.Enabled {


### PR DESCRIPTION
### Applicable Issues

Related to commit dbf61d8 which applied the same change to environmentrequest_controller.go.

### Description of the Change

Apply the same trace context update to environment_controller.go that was done in environmentrequest_controller.go. Replace the single `OTEL_CONTEXT` environment variable with three separate variables (`TRACEPARENT`, `BAGGAGE`, `TRACESTATE`) read directly from annotations. This ensures environment release jobs receive the full trace context needed for proper OpenTelemetry propagation.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com