### PR TITLE
Use rabbitmq-stream URI scheme for SSE config

### DIFF
--- a/internal/etos/api/sse.go
+++ b/internal/etos/api/sse.go
@@ -262,12 +262,12 @@ func (r *ETOSSSEDeployment) config(ctx context.Context, name types.NamespacedNam
 	rabbitmqURL := url.URL{}
 	if d, ok := etos.Data["ETOS_RABBITMQ_SSL"]; ok {
 		if string(d) == "true" {
-			rabbitmqURL.Scheme = "amqps"
+			rabbitmqURL.Scheme = "rabbitmq-stream+tls"
 		} else {
-			rabbitmqURL.Scheme = "amqp"
+			rabbitmqURL.Scheme = "rabbitmq-stream"
 		}
 	} else {
-		rabbitmqURL.Scheme = "amqp"
+		rabbitmqURL.Scheme = "rabbitmq-stream"
 	}
 	if d, ok := etos.Data["ETOS_RABBITMQ_USERNAME"]; ok {
 		rabbitmqURL.User = url.User(string(d))


### PR DESCRIPTION
### Applicable Issues



### Description of the Change

The ETOS controller generates a `ETOS_RABBITMQ_URI` for the SSE service by reading the messagebus secret. The URI scheme was set to `amqps`/`amqp`, but the SSE service uses `rabbitmq-stream-go-client` which requires `rabbitmq-stream+tls://` (for TLS) or `rabbitmq-stream://` (for plaintext) as documented in the [library README](https://github.com/rabbitmq/rabbitmq-stream-go-client/tree/v1.7.1#tls).

This changes the generated URI scheme from `amqps`/`amqp` to `rabbitmq-stream+tls`/`rabbitmq-stream`.

Companion PR: https://github.com/eiffel-community/etos-api/pull/149 (client-side TLS config fix)

### Alternate Designs

Could add a separate field to the SSE config secret instead of changing the URI scheme, but using the correct scheme is cleaner and matches the library's expected protocol URI format.

### Possible Drawbacks

Requires updating etos-api in tandem (see companion PR). The SSE service must be deployed with the matching etos-api version that handles the new scheme.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com