### PR TITLE
Add E2E_REUSE option to skip infra setup in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -ginkgo.timeout=20m -timeout 0
-	$(MAKE) cleanup-test-e2e
+	E2E_REUSE=$(E2E_REUSE) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -ginkgo.timeout=20m -timeout 0
+	@if [ "$(E2E_REUSE)" != "true" ]; then \
+		$(MAKE) cleanup-test-e2e; \
+	else \
+		echo "Skipping cluster cleanup (E2E_REUSE=true)"; \
+	fi
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -ginkgo.timeout=20m -timeout 0
-	$(MAKE) cleanup-test-e2e
+	E2E_REUSE=$(E2E_REUSE) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -ginkgo.timeout=20m -timeout 0
+	@if [ "$(E2E_REUSE)" != "true" ]; then \
+		$(MAKE) cleanup-test-e2e; \
+	else \
+		echo "Skipping cluster cleanup (E2E_REUSE=true)"; \
+	fi
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/test/e2e/e2e_cluster_test.go
+++ b/test/e2e/e2e_cluster_test.go
@@ -30,7 +30,7 @@ func DeployVerifyCluster() {
 	Context("Cluster", func() {
 		It("should be possible to deploy an ETOS cluster", func() {
 			By("deploying the sample Cluster")
-			cmd := exec.Command("kubectl", "create",
+			cmd := exec.Command("kubectl", "apply",
 				"-f", clusterSample,
 				"-n", clusterNamespace)
 			_, err := utils.Run(cmd)

--- a/test/e2e/e2e_controller_test.go
+++ b/test/e2e/e2e_controller_test.go
@@ -89,12 +89,14 @@ func DeployVerifyController() {
 				"--clusterrole=etos-metrics-reader",
 				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+			if _, err := utils.Run(cmd); err != nil {
+				// ClusterRoleBinding may already exist when reusing.
+				_, _ = fmt.Fprintf(GinkgoWriter, "ClusterRoleBinding already exists, continuing\n")
+			}
 
 			By("validating that the metrics service is available")
 			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
+			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
 
 			By("getting the service account token")
@@ -159,6 +161,10 @@ func DeployVerifyController() {
 			time.Sleep(5 * time.Second)
 
 			// +kubebuilder:scaffold:e2e-metrics-webhooks-readiness
+
+			By("cleaning up any existing curl-metrics pod")
+			cmd = exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
 
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			//nolint:lll // Cannot find a good way to reduce the line length for the curl command args.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -35,6 +35,9 @@ var (
 	shouldCleanupCertManager = false
 	// shouldCleanupPrometheus tracks whether Prometheus was installed by this suite.
 	shouldCleanupPrometheus = false
+	// reuseCluster indicates if the cluster and controller should be reused across runs.
+	// Set E2E_REUSE=true to enable this behavior.
+	reuseCluster = os.Getenv("E2E_REUSE") == "true"
 )
 
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
@@ -64,6 +67,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	if reuseCluster {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping suite cleanup (E2E_REUSE=true)\n")
+		return
+	}
 	teardownCertManager()
 	teardownPrometheusOperator()
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,9 @@ var (
 	shouldCleanupCertManager = false
 	// shouldCleanupPrometheus tracks whether Prometheus was installed by this suite.
 	shouldCleanupPrometheus = false
+	// reuseCluster indicates if the cluster and controller should be reused across runs.
+	// Set E2E_REUSE=true to enable this behavior.
+	reuseCluster = os.Getenv("E2E_REUSE") == "true"
 )
 
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
@@ -127,6 +130,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	if reuseCluster {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping suite cleanup (E2E_REUSE=true)\n")
+		return
+	}
 	teardownCertManager()
 	teardownPrometheusOperator()
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,22 +61,36 @@ var _ = Describe("Manager", Ordered, func() {
 	// Before running the tests, set up the environment by creating the namespace,
 	// enforce the restricted security policy to the namespace, installing CRDs,
 	// and deploying the controller.
+	// When E2E_REUSE=true, idempotent commands are used so that existing resources
+	// are reused rather than requiring a fresh setup every time.
 	BeforeAll(func() {
+		if reuseCluster {
+			_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: reusing existing cluster and controller if present\n")
+		}
+
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+		if _, err := utils.Run(cmd); err != nil {
+			// Namespace may already exist when reusing.
+			cmd = exec.Command("kubectl", "get", "ns", namespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Manager namespace does not exist and could not be created")
+		}
 
 		By("labeling the namespace to enforce the restricted security policy")
 		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
 			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
+		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
 		By("creating cluster namespace")
 		cmd = exec.Command("kubectl", "create", "ns", clusterNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+		if _, err = utils.Run(cmd); err != nil {
+			// Namespace may already exist when reusing.
+			cmd = exec.Command("kubectl", "get", "ns", clusterNamespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Cluster namespace does not exist and could not be created")
+		}
 
 		By("installing CRDs")
 		cmd = exec.Command("make", "install")
@@ -84,12 +98,12 @@ var _ = Describe("Manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 		By("deploying the execution space provider")
-		cmd = exec.Command("kubectl", "create", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
+		cmd = exec.Command("kubectl", "apply", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install execution space provider")
 
 		By("deploying the IUT provider")
-		cmd = exec.Command("kubectl", "create", "-k", iutProviderKustomization, "-n", clusterNamespace)
+		cmd = exec.Command("kubectl", "apply", "-k", iutProviderKustomization, "-n", clusterNamespace)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install IUT provider")
 
@@ -97,11 +111,41 @@ var _ = Describe("Manager", Ordered, func() {
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		if reuseCluster {
+			By("waiting for controller-manager rollout to complete")
+			cmd = exec.Command("kubectl", "rollout", "status",
+				"deployment/etos-controller-manager", "-n", namespace, "--timeout=120s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Controller-manager rollout did not complete")
+
+			By("annotating the cluster to trigger reconciliation")
+			cmd = exec.Command("kubectl", "annotate", "cluster", clusterName,
+				"-n", clusterNamespace,
+				fmt.Sprintf("etos.eiffel-community.github.io/reconcile-trigger=%d", time.Now().Unix()),
+				"--overwrite")
+			// Ignore errors here — the cluster may not exist yet on first run.
+			_, _ = utils.Run(cmd)
+		}
 	})
 
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
+	// and deleting the namespace. When E2E_REUSE=true, the controller and cluster infrastructure
+	// are preserved so they can be reused in the next run.
 	AfterAll(func() {
+		if reuseCluster {
+			_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving cluster, controller, CRDs and namespaces\n")
+
+			By("cleaning up the curl-metrics pod to allow re-creation")
+			cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+
+			By("removing metrics clusterrolebinding to allow re-creation")
+			cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			return
+		}
+
 		By("cleaning up the etos cluster")
 		cmd := exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", clusterSample)
 		_, _ = utils.Run(cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -90,15 +90,6 @@ var _ = Describe("Manager", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
-By("deploying the execution space provider")
-		cmd = exec.Command("kubectl", "apply", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install execution space provider")
-
-		By("deploying the IUT provider")
-		cmd = exec.Command("kubectl", "apply", "-k", iutProviderKustomization, "-n", clusterNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install IUT provider")
 		By("deploying the controller-manager")
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage))
 		_, err = utils.Run(cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,37 +54,90 @@ var _ = Describe("Manager", Ordered, func() {
 	// Before running the tests, set up the environment by creating the namespace,
 	// enforce the restricted security policy to the namespace, installing CRDs,
 	// and deploying the controller.
+	// When E2E_REUSE=true, idempotent commands are used so that existing resources
+	// are reused rather than requiring a fresh setup every time.
 	BeforeAll(func() {
+		if reuseCluster {
+			_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: reusing existing cluster and controller if present\n")
+		}
+
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+		if _, err := utils.Run(cmd); err != nil {
+			// Namespace may already exist when reusing.
+			cmd = exec.Command("kubectl", "get", "ns", namespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Manager namespace does not exist and could not be created")
+		}
 
 		By("labeling the namespace to enforce the restricted security policy")
 		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
 			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
+		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
 		By("creating cluster namespace")
 		cmd = exec.Command("kubectl", "create", "ns", clusterNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+		if _, err = utils.Run(cmd); err != nil {
+			// Namespace may already exist when reusing.
+			cmd = exec.Command("kubectl", "get", "ns", clusterNamespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Cluster namespace does not exist and could not be created")
+		}
 
 		By("installing CRDs")
 		cmd = exec.Command("make", "install")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
+By("deploying the execution space provider")
+		cmd = exec.Command("kubectl", "apply", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install execution space provider")
+
+		By("deploying the IUT provider")
+		cmd = exec.Command("kubectl", "apply", "-k", iutProviderKustomization, "-n", clusterNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install IUT provider")
 		By("deploying the controller-manager")
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		if reuseCluster {
+			By("waiting for controller-manager rollout to complete")
+			cmd = exec.Command("kubectl", "rollout", "status",
+				"deployment/etos-controller-manager", "-n", namespace, "--timeout=120s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Controller-manager rollout did not complete")
+
+			By("annotating the cluster to trigger reconciliation")
+			cmd = exec.Command("kubectl", "annotate", "cluster", clusterName,
+				"-n", clusterNamespace,
+				fmt.Sprintf("etos.eiffel-community.github.io/reconcile-trigger=%d", time.Now().Unix()),
+				"--overwrite")
+			// Ignore errors here — the cluster may not exist yet on first run.
+			_, _ = utils.Run(cmd)
+		}
 	})
 
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
+	// and deleting the namespace. When E2E_REUSE=true, the controller and cluster infrastructure
+	// are preserved so they can be reused in the next run.
 	AfterAll(func() {
+		if reuseCluster {
+			_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving cluster, controller, CRDs and namespaces\n")
+
+			By("cleaning up the curl-metrics pod to allow re-creation")
+			cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+
+			By("removing metrics clusterrolebinding to allow re-creation")
+			cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			return
+		}
+
 		By("cleaning up the etos cluster")
 		cmd := exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", clusterSample)
 		_, _ = utils.Run(cmd)

--- a/test/e2e/e2e_testrun_test.go
+++ b/test/e2e/e2e_testrun_test.go
@@ -32,12 +32,14 @@ func VerifyETOSTestruns() {
 	Context("ETOS Testruns", func() {
 		AfterAll(func() {
 			By("cleaning up the artifact injector pod")
-			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace, "--ignore-not-found")
+			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector",
+				"--namespace", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 			By("cleaning up the ETOS testruns")
 			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace, "--ignore-not-found")
+			cmd = exec.Command("kubectl", "delete", "testrun",
+				"testrun-sample-multi-suite", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 
 			By("removing finalizers from EnvironmentRequests and Environments")

--- a/test/e2e/e2e_testrun_test.go
+++ b/test/e2e/e2e_testrun_test.go
@@ -32,12 +32,12 @@ func VerifyETOSTestruns() {
 	Context("ETOS Testruns", func() {
 		AfterAll(func() {
 			By("cleaning up the artifact injector pod")
-			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace)
+			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 			By("cleaning up the ETOS testruns")
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace)
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace)
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 
 			By("removing finalizers from EnvironmentRequests and Environments")
@@ -61,6 +61,14 @@ func VerifyETOSTestruns() {
 				}
 				cmd := exec.Command("kubectl", "patch", "environment", name, "--patch", "{\"metadata\": {\"finalizers\": []}}")
 				_, _ = utils.Run(cmd)
+			}
+
+			if reuseCluster {
+				_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving providers and goer\n")
+				// This wait is necessary to make sure we clean up all resources before
+				// the next test run.
+				time.Sleep(10 * time.Second)
+				return
 			}
 
 			By("cleaning up the goer service")
@@ -95,7 +103,7 @@ func VerifyETOSTestruns() {
 
 		It("should be possible to deploy an ETOS execution space provider", func() {
 			By("deploying the sample Execution space provider")
-			cmd := exec.Command("kubectl", "create",
+			cmd := exec.Command("kubectl", "apply",
 				"-f", executionSpaceProviderSample,
 				"-n", clusterNamespace)
 			_, err := utils.Run(cmd)
@@ -114,7 +122,7 @@ func VerifyETOSTestruns() {
 		})
 		It("should be possible to deploy an ETOS IUT provider", func() {
 			By("deploying the sample IUT provider")
-			cmd := exec.Command("kubectl", "create",
+			cmd := exec.Command("kubectl", "apply",
 				"-f", iutProviderSample,
 				"-n", clusterNamespace)
 			_, err := utils.Run(cmd)
@@ -132,7 +140,7 @@ func VerifyETOSTestruns() {
 		})
 		It("should be possible to deploy an ETOS log area provider", func() {
 			By("deploying the sample Log area provider")
-			cmd := exec.Command("kubectl", "create",
+			cmd := exec.Command("kubectl", "apply",
 				"-f", logAreaProviderSample,
 				"-n", clusterNamespace)
 			_, err := utils.Run(cmd)
@@ -149,7 +157,7 @@ func VerifyETOSTestruns() {
 		})
 		It("should deploy Goer for execution space provider", func() {
 			By("applying the yaml file")
-			cmd := exec.Command("kubectl", "create", "-n", clusterNamespace, "-f", goer)
+			cmd := exec.Command("kubectl", "apply", "-n", clusterNamespace, "-f", goer)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create a goer deployment")
 			verifyGoerReady := func(g Gomega) {
@@ -167,6 +175,11 @@ func VerifyETOSTestruns() {
 			fmt.Sprintf("event = EiffelArtifactCreatedEvent(); event.meta.event_id = '%s';", artifactID) +
 			fmt.Sprintf("event.data.identity = '%s';insert_to_db(event);", artifactIdentity)
 		It("should prepare test environment", func() {
+			By("cleaning up any existing artifact injector pod")
+			cleanupCmd := exec.Command("kubectl", "delete", "pod", "artifact-injector",
+				"--namespace", clusterNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cleanupCmd)
+
 			By("injecting a fake artifact to test")
 			cmd := exec.Command("kubectl", "run", "artifact-injector", "--restart=Never",
 				"--namespace", clusterNamespace,
@@ -200,7 +213,12 @@ func VerifyETOSTestruns() {
 			// TODO: Remove when fixed: https://github.com/eiffel-community/etos/issues/408
 			By("creating a generic encryption key")
 			cmd = exec.Command("kubectl", "create", "secret", "-n", clusterNamespace, "generic",
-				"etos-encryption-key", "--from-literal", "ETOS_ENCRYPTION_KEY=ZmgcW2Qz43KNJfIuF0vYCoPneViMVyObH4GR8R9JE4g=")
+				"etos-encryption-key", "--from-literal", "ETOS_ENCRYPTION_KEY=ZmgcW2Qz43KNJfIuF0vYCoPneViMVyObH4GR8R9JE4g=",
+				"--dry-run=client", "-o", "yaml")
+			secretYaml, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to generate encryption key secret YAML")
+			cmd = exec.Command("kubectl", "apply", "-n", clusterNamespace, "-f", "-")
+			cmd.Stdin = strings.NewReader(secretYaml)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create an encryption key secret")
 			// Getting an EOF error every now and then from the environment-provider.

--- a/test/e2e/e2e_testrun_test.go
+++ b/test/e2e/e2e_testrun_test.go
@@ -35,12 +35,15 @@ func VerifyETOSTestruns() {
 	Context("ETOS Testruns", func() {
 		AfterAll(func() {
 			By("cleaning up the artifact injector pod")
-			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace, "--ignore-not-found")
+			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector",
+				"--namespace", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 			By("cleaning up the ETOS testruns")
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace, "--ignore-not-found")
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample",
+				"-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace, "--ignore-not-found")
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite",
+				"-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 
 			By("removing finalizers from EnvironmentRequests and Environments")
@@ -66,37 +69,14 @@ func VerifyETOSTestruns() {
 				_, _ = utils.Run(cmd)
 			}
 
-if reuseCluster {
-				_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving providers and goer\n")
+			if reuseCluster {
+				_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving cluster resources\n")
 				// This wait is necessary to make sure we clean up all resources before
 				// the next test run.
 				time.Sleep(10 * time.Second)
 				return
 			}
 
-			By("cleaning up the goer service")
-			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", goer)
-			_, _ = utils.Run(cmd)
-
-			By("cleaning up the etos IUT provider")
-			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", iutProviderSample)
-			_, _ = utils.Run(cmd)
-
-			By("cleaning up the etos log area provider")
-			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", logAreaProviderSample)
-			_, _ = utils.Run(cmd)
-
-			By("cleaning up the etos execution space provider")
-			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", executionSpaceProviderSample)
-			_, _ = utils.Run(cmd)
-
-			By("undeploying the IUT provider")
-			cmd = exec.Command("kubectl", "delete", "-k", iutProviderKustomization, "-n", clusterNamespace)
-			_, _ = utils.Run(cmd)
-
-			By("undeploying the execution space provider")
-			cmd = exec.Command("kubectl", "delete", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
-			_, _ = utils.Run(cmd)
 			// This wait is necessary to make sure we clean up all resources before deleting the CRs that are
 			// being used. If we don't delete them the tests won't pass since we'll get stuck waiting for the
 			// namespace being deleted.
@@ -104,7 +84,7 @@ if reuseCluster {
 			time.Sleep(10 * time.Second)
 		})
 
-AfterEach(func() {
+		AfterEach(func() {
 			specReport := CurrentSpecReport()
 			if specReport.Failed() {
 				By("Fetching environment provider pods")
@@ -145,76 +125,6 @@ AfterEach(func() {
 					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testruns, environments and environmentrequests: %s", err)
 				}
 			}
-		})
-
-		It("should be possible to deploy an ETOS execution space provider", func() {
-			By("deploying the sample Execution space provider")
-			cmd := exec.Command("kubectl", "apply",
-				"-f", executionSpaceProviderSample,
-				"-n", clusterNamespace)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			By("checking the status field")
-			verifyExecutionSpace := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"provider", "execution-space-provider-sample", "-o",
-					"jsonpath={.status.conditions[?(@.type=='Available')].status}",
-					"-n", clusterNamespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
-			}
-			Eventually(verifyExecutionSpace).Should(Succeed())
-		})
-		It("should be possible to deploy an ETOS IUT provider", func() {
-			By("deploying the sample IUT provider")
-			cmd := exec.Command("kubectl", "apply",
-				"-f", iutProviderSample,
-				"-n", clusterNamespace)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			By("checking the status field")
-			verifyIut := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"provider", "iut-provider-sample", "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
-					"-n", clusterNamespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
-			}
-			Eventually(verifyIut).Should(Succeed())
-		})
-		It("should be possible to deploy an ETOS log area provider", func() {
-			By("deploying the sample Log area provider")
-			cmd := exec.Command("kubectl", "apply",
-				"-f", logAreaProviderSample,
-				"-n", clusterNamespace)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			verifyLogArea := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"provider", "log-area-provider-sample", "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
-					"-n", clusterNamespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
-			}
-			Eventually(verifyLogArea).Should(Succeed())
-		})
-		It("should deploy Goer for execution space provider", func() {
-			By("applying the yaml file")
-			cmd := exec.Command("kubectl", "apply", "-n", clusterNamespace, "-f", goer)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create a goer deployment")
-			verifyGoerReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get",
-					"deploy", "goer", "-o", "jsonpath={.status.readyReplicas}",
-					"-n", clusterNamespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("1"), "Incorrect Eiffel Goer deployment status")
-			}
-			Eventually(verifyGoerReady).Should(Succeed())
 		})
 
 		cmd := "from eiffel_graphql_api.graphql.db.database import insert_to_db;" +

--- a/test/e2e/e2e_testrun_test.go
+++ b/test/e2e/e2e_testrun_test.go
@@ -35,12 +35,12 @@ func VerifyETOSTestruns() {
 	Context("ETOS Testruns", func() {
 		AfterAll(func() {
 			By("cleaning up the artifact injector pod")
-			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace)
+			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 			By("cleaning up the ETOS testruns")
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace)
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace)
+			cmd = exec.Command("kubectl", "delete", "testrun", "testrun-sample-multi-suite", "-n", clusterNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 
 			By("removing finalizers from EnvironmentRequests and Environments")
@@ -66,6 +66,37 @@ func VerifyETOSTestruns() {
 				_, _ = utils.Run(cmd)
 			}
 
+if reuseCluster {
+				_, _ = fmt.Fprintf(GinkgoWriter, "E2E_REUSE=true: preserving providers and goer\n")
+				// This wait is necessary to make sure we clean up all resources before
+				// the next test run.
+				time.Sleep(10 * time.Second)
+				return
+			}
+
+			By("cleaning up the goer service")
+			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", goer)
+			_, _ = utils.Run(cmd)
+
+			By("cleaning up the etos IUT provider")
+			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", iutProviderSample)
+			_, _ = utils.Run(cmd)
+
+			By("cleaning up the etos log area provider")
+			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", logAreaProviderSample)
+			_, _ = utils.Run(cmd)
+
+			By("cleaning up the etos execution space provider")
+			cmd = exec.Command("kubectl", "delete", "-n", clusterNamespace, "-f", executionSpaceProviderSample)
+			_, _ = utils.Run(cmd)
+
+			By("undeploying the IUT provider")
+			cmd = exec.Command("kubectl", "delete", "-k", iutProviderKustomization, "-n", clusterNamespace)
+			_, _ = utils.Run(cmd)
+
+			By("undeploying the execution space provider")
+			cmd = exec.Command("kubectl", "delete", "-k", executionSpaceProviderKustomization, "-n", clusterNamespace)
+			_, _ = utils.Run(cmd)
 			// This wait is necessary to make sure we clean up all resources before deleting the CRs that are
 			// being used. If we don't delete them the tests won't pass since we'll get stuck waiting for the
 			// namespace being deleted.
@@ -73,7 +104,7 @@ func VerifyETOSTestruns() {
 			time.Sleep(10 * time.Second)
 		})
 
-		AfterEach(func() {
+AfterEach(func() {
 			specReport := CurrentSpecReport()
 			if specReport.Failed() {
 				By("Fetching environment provider pods")
@@ -116,11 +147,86 @@ func VerifyETOSTestruns() {
 			}
 		})
 
+		It("should be possible to deploy an ETOS execution space provider", func() {
+			By("deploying the sample Execution space provider")
+			cmd := exec.Command("kubectl", "apply",
+				"-f", executionSpaceProviderSample,
+				"-n", clusterNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			By("checking the status field")
+			verifyExecutionSpace := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"provider", "execution-space-provider-sample", "-o",
+					"jsonpath={.status.conditions[?(@.type=='Available')].status}",
+					"-n", clusterNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
+			}
+			Eventually(verifyExecutionSpace).Should(Succeed())
+		})
+		It("should be possible to deploy an ETOS IUT provider", func() {
+			By("deploying the sample IUT provider")
+			cmd := exec.Command("kubectl", "apply",
+				"-f", iutProviderSample,
+				"-n", clusterNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			By("checking the status field")
+			verifyIut := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"provider", "iut-provider-sample", "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+					"-n", clusterNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
+			}
+			Eventually(verifyIut).Should(Succeed())
+		})
+		It("should be possible to deploy an ETOS log area provider", func() {
+			By("deploying the sample Log area provider")
+			cmd := exec.Command("kubectl", "apply",
+				"-f", logAreaProviderSample,
+				"-n", clusterNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			verifyLogArea := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"provider", "log-area-provider-sample", "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+					"-n", clusterNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"), "Incorrect Provider status")
+			}
+			Eventually(verifyLogArea).Should(Succeed())
+		})
+		It("should deploy Goer for execution space provider", func() {
+			By("applying the yaml file")
+			cmd := exec.Command("kubectl", "apply", "-n", clusterNamespace, "-f", goer)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create a goer deployment")
+			verifyGoerReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"deploy", "goer", "-o", "jsonpath={.status.readyReplicas}",
+					"-n", clusterNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"), "Incorrect Eiffel Goer deployment status")
+			}
+			Eventually(verifyGoerReady).Should(Succeed())
+		})
+
 		cmd := "from eiffel_graphql_api.graphql.db.database import insert_to_db;" +
 			"from eiffellib.events import EiffelArtifactCreatedEvent;" +
 			fmt.Sprintf("event = EiffelArtifactCreatedEvent(); event.meta.event_id = '%s';", artifactID) +
 			fmt.Sprintf("event.data.identity = '%s';insert_to_db(event);", artifactIdentity)
 		It("should prepare test environment", func() {
+			By("cleaning up any existing artifact injector pod")
+			cleanupCmd := exec.Command("kubectl", "delete", "pod", "artifact-injector",
+				"--namespace", clusterNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cleanupCmd)
+
 			By("injecting a fake artifact to test")
 			cmd := exec.Command("kubectl", "run", "artifact-injector", "--restart=Never",
 				"--namespace", clusterNamespace,
@@ -154,7 +260,12 @@ func VerifyETOSTestruns() {
 			// TODO: Remove when fixed: https://github.com/eiffel-community/etos/issues/408
 			By("creating a generic encryption key")
 			cmd = exec.Command("kubectl", "create", "secret", "-n", clusterNamespace, "generic",
-				"etos-encryption-key", "--from-literal", "ETOS_ENCRYPTION_KEY=ZmgcW2Qz43KNJfIuF0vYCoPneViMVyObH4GR8R9JE4g=")
+				"etos-encryption-key", "--from-literal", "ETOS_ENCRYPTION_KEY=ZmgcW2Qz43KNJfIuF0vYCoPneViMVyObH4GR8R9JE4g=",
+				"--dry-run=client", "-o", "yaml")
+			secretYaml, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to generate encryption key secret YAML")
+			cmd = exec.Command("kubectl", "apply", "-n", clusterNamespace, "-f", "-")
+			cmd.Stdin = strings.NewReader(secretYaml)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create an encryption key secret")
 		})


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/500

### Description of the Change

Add opt-in `E2E_REUSE=true` flag for `make test-e2e` that preserves the Kind cluster, cert-manager, controller, and CRDs between runs. On a warm cluster, a full e2e pass drops from ~580s to ~330s (43% faster): BeforeSuite goes from 31s to 1.7s, AfterSuite from 15.5s to 0s, and cold-start delays are eliminated.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com