### PR TITLE
Skip MongoDB deployment when event repository is disabled

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -115,7 +115,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	mongodb := extras.NewMongoDBDeployment(cluster.Spec.EventRepository.Database, r.Scheme, r.Client)
+	// MongoDB is only used by the local event repository. When the event repository
+	// is not deployed, force MongoDB deploy to false to avoid creating unused resources.
+	mongoSpec := cluster.Spec.EventRepository.Database
+	if !cluster.Spec.EventRepository.Deploy {
+		mongoSpec.Deploy = false
+	}
+	mongodb := extras.NewMongoDBDeployment(mongoSpec, r.Scheme, r.Client)
 	if err := mongodb.Reconcile(ctx, cluster); err != nil {
 		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
 			return ctrl.Result{Requeue: true}, nil


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/623

### Description of the Change

When `eventRepository.deploy` is `false`, the controller now forces `mongo.deploy` to `false` before reconciling MongoDB. This prevents an unused MongoDB pod from being deployed when using an external event repository.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com