### PR TITLE
Pin kubexit init container image to digest

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -788,9 +788,10 @@ func (r TestRunReconciler) suiteRunnerJob(ctx context.Context, obj client.Object
 					RestartPolicy:                 "Never",
 					InitContainers: []corev1.Container{
 						{
-							Name:    "kubexit",
-							Image:   "karlkfi/kubexit:latest",
-							Command: []string{"cp", "/bin/kubexit", "/kubexit/kubexit"},
+							Name:            "kubexit",
+							Image:           "karlkfi/kubexit@sha256:db2dac0ab628d90cbdfd2a6827c14565d0230de57889c29108be111de45a6099",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         []string{"cp", "/bin/kubexit", "/kubexit/kubexit"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("64Mi"),

--- a/internal/etos/suitestarter/suitestarter.go
+++ b/internal/etos/suitestarter/suitestarter.go
@@ -624,7 +624,8 @@ func (r *ETOSSuiteStarterDeployment) suiteRunnerTemplate(templateName types.Name
                 medium: Memory
             initContainers:
             - name: kubexit
-              image: karlkfi/kubexit:latest
+              image: karlkfi/kubexit@sha256:db2dac0ab628d90cbdfd2a6827c14565d0230de57889c29108be111de45a6099
+              imagePullPolicy: IfNotPresent
               command: ["cp", "/bin/kubexit", "/kubexit/kubexit"]
               resources:
                 requests:


### PR DESCRIPTION
### Applicable Issues



### Description of the Change

Pin the kubexit init container image from `karlkfi/kubexit:latest` to its SHA256 digest and set `imagePullPolicy: IfNotPresent`. Using `:latest` causes Kubernetes to always pull the image from Docker Hub, which is subject to rate limits. Pinning to the digest ensures reproducible builds and allows the image to be cached locally.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com