### PR TITLE
Pin RabbitMQ to 4.3.0 and default queue params to durable

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -53,7 +53,8 @@ type EventRepository struct {
 	// +kubebuilder:default="etos"
 	// +optional
 	EiffelQueueName string `json:"eiffelQueueName,omitempty"`
-	// EiffelQueueParams are the parameters to use for the event repository queue. Defaults to empty.
+	// EiffelQueueParams are the parameters to use for the event repository queue.
+	// +kubebuilder:default="{\"durable\": true}"
 	// +optional
 	EiffelQueueParams string `json:"eiffelQueueParams,omitempty"`
 
@@ -205,7 +206,8 @@ type ETOSSuiteStarter struct {
 	// +kubebuilder:default="etos-suite-starter"
 	// +optional
 	EiffelQueueName string `json:"eiffelQueueName,omitempty"`
-	// EiffelQueueParams are the parameters to use for the suite starter queue. Defaults to empty.
+	// EiffelQueueParams are the parameters to use for the suite starter queue.
+	// +kubebuilder:default="{\"durable\": true}"
 	// +optional
 	EiffelQueueParams string `json:"eiffelQueueParams,omitempty"`
 	// Provide a custom suite runner template.
@@ -244,7 +246,8 @@ type ETOSLogListener struct {
 	// +kubebuilder:default="etos-*-temp"
 	// +optional
 	ETOSQueueName string `json:"etosQueueName,omitempty"`
-	// ETOSQueueParams are the parameters to use for the log listener queue. Defaults to empty.
+	// ETOSQueueParams are the parameters to use for the log listener queue.
+	// +kubebuilder:default="{\"durable\": true}"
 	// +optional
 	ETOSQueueParams string `json:"etosQueueParams,omitempty"`
 }

--- a/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
@@ -372,8 +372,9 @@ spec:
                               conflicts between multiple log listeners.
                             type: string
                           etosQueueParams:
+                            default: '{"durable": true}'
                             description: ETOSQueueParams are the parameters to use
-                              for the log listener queue. Defaults to empty.
+                              for the log listener queue.
                             type: string
                           image:
                             description: Image describes the docker image to run for
@@ -422,8 +423,9 @@ spec:
                           incoming Eiffel events. Defaults to "etos-suite-starter".
                         type: string
                       eiffelQueueParams:
+                        default: '{"durable": true}'
                         description: EiffelQueueParams are the parameters to use for
-                          the suite starter queue. Defaults to empty.
+                          the suite starter queue.
                         type: string
                       image:
                         description: Image describes the docker image to run for a
@@ -487,8 +489,9 @@ spec:
                       the event repository. Defaults to "etos".
                     type: string
                   eiffelQueueParams:
+                    default: '{"durable": true}'
                     description: EiffelQueueParams are the parameters to use for the
-                      event repository queue. Defaults to empty.
+                      event repository queue.
                     type: string
                   host:
                     description: Host specifies the event repository API URL. Required

--- a/internal/extras/eventrepository.go
+++ b/internal/extras/eventrepository.go
@@ -17,6 +17,7 @@ package extras
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/url"
@@ -259,6 +260,12 @@ func (r *EventRepositoryDeployment) config(ctx context.Context, name types.Names
 	maps.Copy(data, etos.Data)
 	data["RABBITMQ_QUEUE"] = []byte(r.EiffelQueueName)
 	data["RABBITMQ_QUEUE_PARAMS"] = []byte(r.EiffelQueueParams)
+	var queueParams map[string]any
+	if err := json.Unmarshal([]byte(r.EiffelQueueParams), &queueParams); err == nil {
+		if durable, ok := queueParams["durable"].(bool); ok && durable {
+			data["RABBITMQ_DURABLE_QUEUE"] = []byte("true")
+		}
+	}
 	return &corev1.Secret{
 		ObjectMeta: r.meta(name, clusterName),
 		Data:       data,

--- a/internal/extras/messagebus.go
+++ b/internal/extras/messagebus.go
@@ -356,7 +356,7 @@ func (r *MessageBusDeployment) volumes(name types.NamespacedName) []corev1.Volum
 func (r *MessageBusDeployment) container(name types.NamespacedName) corev1.Container {
 	return corev1.Container{
 		Name:  name.Name,
-		Image: "rabbitmq:latest",
+		Image: "rabbitmq:4.3.0",
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      fmt.Sprintf("%s-data", name.Name),

--- a/internal/extras/rabbitmq.go
+++ b/internal/extras/rabbitmq.go
@@ -291,7 +291,7 @@ func (r *RabbitMQDeployment) volume(name types.NamespacedName) corev1.Volume {
 func (r *RabbitMQDeployment) container(name types.NamespacedName) corev1.Container {
 	return corev1.Container{
 		Name:  name.Name,
-		Image: "rabbitmq:latest",
+		Image: "rabbitmq:4.3.0",
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      fmt.Sprintf("%s-data", name.Name),


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/628

### Description of the Change

Pins the RabbitMQ image to 4.3.0 instead of `latest` and defaults all queue params to `{"durable": true}` in the CRD, since RabbitMQ 4.3.0 no longer allows transient non-exclusive queues by default.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com