### PR TITLE
Fix E2E diagnostics: collect before cleanup, add pod logs

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,9 +136,18 @@ var _ = Describe("Manager", Ordered, func() {
 			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
 			eventsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events in %s:\n%s", namespace, eventsOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events from %s: %s", namespace, err)
+			}
+
+			By("Fetching Kubernetes events from cluster namespace")
+			cmd = exec.Command("kubectl", "get", "events", "-n", clusterNamespace, "--sort-by=.lastTimestamp")
+			clusterEventsOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events in %s:\n%s", clusterNamespace, clusterEventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events from %s: %s", clusterNamespace, err)
 			}
 
 			By("Fetching curl-metrics logs")
@@ -157,6 +166,61 @@ var _ = Describe("Manager", Ordered, func() {
 				fmt.Println("Pod description:\n", podDescription)
 			} else {
 				fmt.Println("Failed to describe controller pod")
+			}
+
+			By("Fetching testrun description")
+			cmd = exec.Command("kubectl", "describe", "testruns", "-n", clusterNamespace)
+			testrunOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Testrun description:\n %s", testrunOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testrun description: %s", err)
+			}
+
+			By("Fetching testrun, environment and environmentrequests")
+			cmd = exec.Command("kubectl", "get", "testruns,environments,environmentrequests", "-n", clusterNamespace)
+			listOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Testruns, environments and environmentrequests:\n %s", listOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testruns, environments and environmentrequests: %s", err)
+			}
+
+			By("Fetching suite runner pod logs")
+			cmd = exec.Command("kubectl", "get", "pods", "-l", "etos.eiffel-community.github.io/id",
+				"-o", "custom-columns=:metadata.name", "--no-headers", "-n", clusterNamespace)
+			suiteRunnerPods, err := utils.Run(cmd)
+			if err == nil {
+				for _, podName := range utils.GetNonEmptyLines(suiteRunnerPods) {
+					_, _ = fmt.Fprintf(GinkgoWriter, "--- Logs for suite runner pod %s ---\n", podName)
+					logCmd := exec.Command("kubectl", "logs", podName, "--all-containers", "-n", clusterNamespace)
+					logOutput, logErr := utils.Run(logCmd)
+					if logErr == nil {
+						_, _ = fmt.Fprintf(GinkgoWriter, "%s\n", logOutput)
+					} else {
+						_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get logs for pod %s: %s\n", podName, logErr)
+					}
+				}
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to list suite runner pods: %s", err)
+			}
+
+			By("Describing suite runner pods")
+			cmd = exec.Command("kubectl", "describe", "pods", "-l", "etos.eiffel-community.github.io/id", "-n", clusterNamespace)
+			suiteRunnerDesc, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Suite runner pod descriptions:\n%s", suiteRunnerDesc)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to describe suite runner pods: %s", err)
+			}
+
+			By("Fetching Jobs in cluster namespace")
+			cmd = exec.Command("kubectl", "get", "jobs", "-n", clusterNamespace, "-o", "wide")
+			jobsOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Jobs in %s:\n%s", clusterNamespace, jobsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get jobs from %s: %s", clusterNamespace, err)
 			}
 		}
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -141,15 +141,6 @@ var _ = Describe("Manager", Ordered, func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events from %s: %s", namespace, err)
 			}
 
-			By("Fetching Kubernetes events from cluster namespace")
-			cmd = exec.Command("kubectl", "get", "events", "-n", clusterNamespace, "--sort-by=.lastTimestamp")
-			clusterEventsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events in %s:\n%s", clusterNamespace, clusterEventsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events from %s: %s", clusterNamespace, err)
-			}
-
 			By("Fetching curl-metrics logs")
 			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 			metricsOutput, err := utils.Run(cmd)
@@ -166,61 +157,6 @@ var _ = Describe("Manager", Ordered, func() {
 				fmt.Println("Pod description:\n", podDescription)
 			} else {
 				fmt.Println("Failed to describe controller pod")
-			}
-
-			By("Fetching testrun description")
-			cmd = exec.Command("kubectl", "describe", "testruns", "-n", clusterNamespace)
-			testrunOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Testrun description:\n %s", testrunOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testrun description: %s", err)
-			}
-
-			By("Fetching testrun, environment and environmentrequests")
-			cmd = exec.Command("kubectl", "get", "testruns,environments,environmentrequests", "-n", clusterNamespace)
-			listOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Testruns, environments and environmentrequests:\n %s", listOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testruns, environments and environmentrequests: %s", err)
-			}
-
-			By("Fetching suite runner pod logs")
-			cmd = exec.Command("kubectl", "get", "pods", "-l", "etos.eiffel-community.github.io/id",
-				"-o", "custom-columns=:metadata.name", "--no-headers", "-n", clusterNamespace)
-			suiteRunnerPods, err := utils.Run(cmd)
-			if err == nil {
-				for _, podName := range utils.GetNonEmptyLines(suiteRunnerPods) {
-					_, _ = fmt.Fprintf(GinkgoWriter, "--- Logs for suite runner pod %s ---\n", podName)
-					logCmd := exec.Command("kubectl", "logs", podName, "--all-containers", "-n", clusterNamespace)
-					logOutput, logErr := utils.Run(logCmd)
-					if logErr == nil {
-						_, _ = fmt.Fprintf(GinkgoWriter, "%s\n", logOutput)
-					} else {
-						_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get logs for pod %s: %s\n", podName, logErr)
-					}
-				}
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to list suite runner pods: %s", err)
-			}
-
-			By("Describing suite runner pods")
-			cmd = exec.Command("kubectl", "describe", "pods", "-l", "etos.eiffel-community.github.io/id", "-n", clusterNamespace)
-			suiteRunnerDesc, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Suite runner pod descriptions:\n%s", suiteRunnerDesc)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to describe suite runner pods: %s", err)
-			}
-
-			By("Fetching Jobs in cluster namespace")
-			cmd = exec.Command("kubectl", "get", "jobs", "-n", clusterNamespace, "-o", "wide")
-			jobsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Jobs in %s:\n%s", clusterNamespace, jobsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get jobs from %s: %s", clusterNamespace, err)
 			}
 		}
 	})

--- a/test/e2e/e2e_testrun_test.go
+++ b/test/e2e/e2e_testrun_test.go
@@ -34,6 +34,83 @@ const Failed = "Failed"
 func VerifyETOSTestruns() {
 	Context("ETOS Testruns", func() {
 		AfterAll(func() {
+			// Collect diagnostics BEFORE cleanup to ensure testrun state,
+			// suite runner pod logs, and events are captured while resources
+			// still exist. The outer AfterEach may not reliably run before
+			// this AfterAll for cross-container ordering.
+			specReport := CurrentSpecReport()
+			if specReport.Failed() {
+				By("Collecting testrun diagnostics before cleanup")
+
+				By("Fetching testrun descriptions")
+				cmd := exec.Command("kubectl", "describe", "testruns", "-n", clusterNamespace)
+				output, err := utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Testrun descriptions:\n%s", output)
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testrun descriptions: %s", err)
+				}
+
+				By("Fetching testruns, environments, and environmentrequests")
+				cmd = exec.Command("kubectl", "get", "testruns,environments,environmentrequests", "-n", clusterNamespace)
+				output, err = utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Testruns, environments and environmentrequests:\n%s", output)
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get testruns, environments and environmentrequests: %s", err)
+				}
+
+				By("Fetching suite runner pod logs")
+				cmd = exec.Command("kubectl", "get", "pods", "-l", "etos.eiffel-community.github.io/id",
+					"-o", "custom-columns=:metadata.name", "--no-headers", "-n", clusterNamespace)
+				output, err = utils.Run(cmd)
+				if err == nil {
+					for name := range strings.SplitSeq(output, "\n") {
+						if name == "" {
+							continue
+						}
+						_, _ = fmt.Fprintf(GinkgoWriter, "--- Logs for pod %s ---\n", name)
+						logCmd := exec.Command("kubectl", "logs", name, "--all-containers", "-n", clusterNamespace)
+						logOutput, logErr := utils.Run(logCmd)
+						if logErr == nil {
+							_, _ = fmt.Fprintf(GinkgoWriter, "%s\n", logOutput)
+						} else {
+							_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get logs for pod %s: %s\n", name, logErr)
+						}
+					}
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to list suite runner pods: %s", err)
+				}
+
+				By("Fetching events from cluster namespace")
+				cmd = exec.Command("kubectl", "get", "events", "-n", clusterNamespace, "--sort-by=.lastTimestamp")
+				output, err = utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Events in %s:\n%s", clusterNamespace, output)
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get events from %s: %s", clusterNamespace, err)
+				}
+
+				By("Describing suite runner pods")
+				cmd = exec.Command("kubectl", "describe", "pods",
+					"-l", "etos.eiffel-community.github.io/id", "-n", clusterNamespace)
+				output, err = utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Suite runner pod descriptions:\n%s", output)
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to describe suite runner pods: %s", err)
+				}
+
+				By("Fetching Jobs in cluster namespace")
+				cmd = exec.Command("kubectl", "get", "jobs", "-n", clusterNamespace, "-o", "wide")
+				output, err = utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Jobs in %s:\n%s", clusterNamespace, output)
+				} else {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get jobs from %s: %s", clusterNamespace, err)
+				}
+			}
+
 			By("cleaning up the artifact injector pod")
 			cmd := exec.Command("kubectl", "delete", "pod", "artifact-injector", "--namespace", clusterNamespace)
 			_, _ = utils.Run(cmd)


### PR DESCRIPTION
### Applicable Issues



### Description of the Change

Improve E2E test diagnostics by collecting pod descriptions and logs before test cleanup deletes them. Adds suite runner and test runner pod log collection in the AfterAll block, ensuring diagnostic data is available when investigating test failures.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com