### PR TITLE
Inject test result timeout into provider env vars

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -296,6 +296,12 @@ type ETOSConfig struct {
 	// +kubebuilder:default="3600"
 	// +required
 	EnvironmentTimeout string `json:"environmentTimeout,omitempty"`
+	// TestResultTimeout describes the maximum time in seconds that test results are expected to
+	// be available. This value is used as the basis for etcd key TTLs in the IUT and execution
+	// space provider services. Defaults to 86400 seconds (24 hours) if not set.
+	// +kubebuilder:default="86400"
+	// +optional
+	TestResultTimeout string `json:"testResultTimeout,omitempty"`
 	// Source describes the source tag added to all Eiffel events sent by ETOS.
 	// +kubebuilder:default="ETOS"
 	// +required

--- a/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_clusters.yaml
@@ -245,6 +245,13 @@ spec:
                         description: Source describes the source tag added to all
                           Eiffel events sent by ETOS.
                         type: string
+                      testResultTimeout:
+                        default: "86400"
+                        description: |-
+                          TestResultTimeout describes the maximum time in seconds that test results are expected to
+                          be available. This value is used as the basis for etcd key TTLs in the IUT and execution
+                          space provider services. Defaults to 86400 seconds (24 hours) if not set.
+                        type: string
                       testSuiteTimeout:
                         default: "10"
                         description: |-

--- a/internal/etos/etos.go
+++ b/internal/etos/etos.go
@@ -352,6 +352,7 @@ func (r *ETOSDeployment) reconcileIutProvider(ctx context.Context, name types.Na
 	logger := log.FromContext(ctx)
 	name = types.NamespacedName{Name: fmt.Sprintf("%s-iut-provider", name.Name), Namespace: name.Namespace}
 	target := r.provider(name, "iut", config.ImageOrDefault(r.cfg.IutProvider, etosv1alpha1.Image{}), owner.GetName())
+	target.Spec.Env = r.testResultTimeoutEnv()
 	if err := ctrl.SetControllerReference(owner, target, r.Scheme); err != nil {
 		return target, err
 	}
@@ -415,6 +416,7 @@ func (r *ETOSDeployment) reconcileExecutionSpaceProvider(ctx context.Context, na
 	logger := log.FromContext(ctx)
 	name = types.NamespacedName{Name: fmt.Sprintf("%s-execution-space-provider", name.Name), Namespace: name.Namespace}
 	target := r.provider(name, "execution-space", config.ImageOrDefault(r.cfg.ExecutionSpaceProvider, etosv1alpha1.Image{}), owner.GetName())
+	target.Spec.Env = r.testResultTimeoutEnv()
 	if err := ctrl.SetControllerReference(owner, target, r.Scheme); err != nil {
 		return target, err
 	}
@@ -435,6 +437,19 @@ func (r *ETOSDeployment) reconcileExecutionSpaceProvider(ctx context.Context, na
 	// by default when creating custom resources.
 	target.ObjectMeta = provider.ObjectMeta
 	return target, r.Patch(ctx, target, client.MergeFrom(provider))
+}
+
+// testResultTimeoutEnv returns environment variables for the test result timeout
+// configuration. This sets ETOS_DEFAULT_TEST_RESULT_TIMEOUT in the provider containers
+// so that the etcd key TTL matches the configured timeout.
+func (r *ETOSDeployment) testResultTimeoutEnv() []corev1.EnvVar {
+	timeout := r.ETOS.Config.TestResultTimeout
+	if timeout == "" {
+		timeout = "86400"
+	}
+	return []corev1.EnvVar{
+		{Name: "ETOS_DEFAULT_TEST_RESULT_TIMEOUT", Value: timeout},
+	}
 }
 
 // provider creates a provider definition for the ETOS API.

--- a/internal/etos/etos.go
+++ b/internal/etos/etos.go
@@ -443,7 +443,7 @@ func (r *ETOSDeployment) reconcileExecutionSpaceProvider(ctx context.Context, na
 // configuration. This sets ETOS_DEFAULT_TEST_RESULT_TIMEOUT in the provider containers
 // so that the etcd key TTL matches the configured timeout.
 func (r *ETOSDeployment) testResultTimeoutEnv() []corev1.EnvVar {
-	timeout := r.ETOS.Config.TestResultTimeout
+	timeout := r.Config.TestResultTimeout
 	if timeout == "" {
 		timeout = "86400"
 	}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/639

Related to https://github.com/eiffel-community/etos-api/pull/156

### Description of the Change

Add `TestResultTimeout` to `ETOSConfig` CRD (default 86400s) and inject it as `ETOS_DEFAULT_TEST_RESULT_TIMEOUT` env var into IUT and ExecutionSpace providers so etcd key TTLs match the configured timeout.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com