### PR TITLE
Convert generateName to RFC1123 DNS subdomain format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out -v -ginkgo.v
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out -v
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/pkg/provider/executionspace.go
+++ b/pkg/provider/executionspace.go
@@ -113,9 +113,9 @@ func CreateExecutionSpace(
 
 	var generateName string
 	if name == "" {
-		// 253 is the maximum length for a name, and we need to reserve one character for the
-		// hyphen added by generateName, so we use 252 here.
-		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
+		// 63 is the maximum length for generateName, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 62 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 62))
 	}
 
 	isController := false

--- a/pkg/provider/executionspace.go
+++ b/pkg/provider/executionspace.go
@@ -18,7 +18,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
@@ -114,7 +113,9 @@ func CreateExecutionSpace(
 
 	var generateName string
 	if name == "" {
-		generateName = toRFC1123(fmt.Sprintf("%s-execution-space-", strings.ToLower(environmentrequest.Spec.Name)))
+		// 253 is the maximum length for a name, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 252 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
 	}
 
 	isController := false

--- a/pkg/provider/executionspace.go
+++ b/pkg/provider/executionspace.go
@@ -114,7 +114,7 @@ func CreateExecutionSpace(
 
 	var generateName string
 	if name == "" {
-		generateName = fmt.Sprintf("%s-execution-space-", strings.ToLower(environmentrequest.Spec.Name))
+		generateName = toRFC1123(fmt.Sprintf("%s-execution-space-", strings.ToLower(environmentrequest.Spec.Name)))
 	}
 
 	isController := false

--- a/pkg/provider/iut.go
+++ b/pkg/provider/iut.go
@@ -18,7 +18,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
@@ -124,7 +123,9 @@ func CreateIUT(
 
 	var generateName string
 	if name == "" {
-		generateName = toRFC1123(fmt.Sprintf("%s-iut-", strings.ToLower(environmentrequest.Spec.Name)))
+		// 253 is the maximum length for a name, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 252 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
 	}
 
 	isController := false

--- a/pkg/provider/iut.go
+++ b/pkg/provider/iut.go
@@ -124,7 +124,7 @@ func CreateIUT(
 
 	var generateName string
 	if name == "" {
-		generateName = fmt.Sprintf("%s-iut-", strings.ToLower(environmentrequest.Spec.Name))
+		generateName = toRFC1123(fmt.Sprintf("%s-iut-", strings.ToLower(environmentrequest.Spec.Name)))
 	}
 
 	isController := false

--- a/pkg/provider/iut.go
+++ b/pkg/provider/iut.go
@@ -123,9 +123,9 @@ func CreateIUT(
 
 	var generateName string
 	if name == "" {
-		// 253 is the maximum length for a name, and we need to reserve one character for the
-		// hyphen added by generateName, so we use 252 here.
-		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
+		// 63 is the maximum length for generateName, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 62 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 62))
 	}
 
 	isController := false

--- a/pkg/provider/logarea.go
+++ b/pkg/provider/logarea.go
@@ -18,7 +18,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
@@ -121,7 +120,9 @@ func CreateLogArea(
 
 	var generateName string
 	if name == "" {
-		generateName = toRFC1123(fmt.Sprintf("%s-log-area-", strings.ToLower(environmentrequest.Spec.Name)))
+		// 253 is the maximum length for a name, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 252 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
 	}
 
 	isController := false

--- a/pkg/provider/logarea.go
+++ b/pkg/provider/logarea.go
@@ -120,9 +120,9 @@ func CreateLogArea(
 
 	var generateName string
 	if name == "" {
-		// 253 is the maximum length for a name, and we need to reserve one character for the
-		// hyphen added by generateName, so we use 252 here.
-		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 252))
+		// 63 is the maximum length for generateName, and we need to reserve one character for the
+		// hyphen added by generateName, so we use 62 here.
+		generateName = fmt.Sprintf("%s-", toRFC1123(environmentrequest.Spec.Name, 62))
 	}
 
 	isController := false

--- a/pkg/provider/logarea.go
+++ b/pkg/provider/logarea.go
@@ -121,7 +121,7 @@ func CreateLogArea(
 
 	var generateName string
 	if name == "" {
-		generateName = fmt.Sprintf("%s-log-area-", strings.ToLower(environmentrequest.Spec.Name))
+		generateName = toRFC1123(fmt.Sprintf("%s-log-area-", strings.ToLower(environmentrequest.Spec.Name)))
 	}
 
 	isController := false

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -261,8 +261,9 @@ func writeTerminationLog(
 	return nil
 }
 
-// toRFC1123 converts a string to a valid RFC1123 dns subdomain by replacing invalid characters
-// with hyphens, converting to lowercase and ensuring it doesn't exceed maxlen characters.
+// toRFC1123 converts a string to a valid RFC1123 dns subdomain (but with a variable length)
+// by replacing invalid characters with hyphens, converting to lowercase and ensuring it
+// doesn't exceed maxlen characters.
 func toRFC1123(s string, maxlen int) string {
 	s = strings.ToLower(s)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -42,6 +42,8 @@ var (
 	cli            client.Client
 	Scheme         = runtime.NewScheme()
 	terminationLog = "/dev/termination-log"
+
+	nonAlphanumerics = regexp.MustCompile(`[^a-z0-9]+`)
 )
 
 type AmountFunc func(context.Context, *v1alpha1.EnvironmentRequest) (int, error)
@@ -260,19 +262,17 @@ func writeTerminationLog(
 }
 
 // toRFC1123 converts a string to a valid RFC1123 dns subdomain by replacing invalid characters
-// with hyphens, converting to lowercase and ensuring it doesn't exceed 253 characters.
-func toRFC1123(s string) string {
+// with hyphens, converting to lowercase and ensuring it doesn't exceed maxlen characters.
+func toRFC1123(s string, maxlen int) string {
 	s = strings.ToLower(s)
 
 	// Replace any non-alphanumeric character with a hyphen
-	reg := regexp.MustCompile(`[^a-z0-9]+`)
-	s = reg.ReplaceAllString(s, "-")
-
+	s = nonAlphanumerics.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-")
 
 	// 253 characters is the maximum length for an RFC1123 resource name in Kubernetes
-	if len(s) > 253 {
-		s = s[:253]
+	if len(s) > maxlen {
+		s = s[:maxlen]
 	}
 
 	// Ensure it doesn't end with a hyphen after truncation

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -22,6 +22,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
@@ -255,4 +257,26 @@ func writeTerminationLog(
 		return err
 	}
 	return nil
+}
+
+// toRFC1123 converts a string to a valid RFC1123 dns subdomain by replacing invalid characters
+// with hyphens, converting to lowercase and ensuring it doesn't exceed 253 characters.
+func toRFC1123(s string) string {
+	s = strings.ToLower(s)
+
+	// Replace any non-alphanumeric character with a hyphen
+	reg := regexp.MustCompile(`[^a-z0-9]+`)
+	s = reg.ReplaceAllString(s, "-")
+
+	s = strings.Trim(s, "-")
+
+	// 253 characters is the maximum length for an RFC1123 resource name in Kubernetes
+	if len(s) > 253 {
+		s = s[:253]
+	}
+
+	// Ensure it doesn't end with a hyphen after truncation
+	s = strings.TrimSuffix(s, "-")
+
+	return s
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -270,7 +270,6 @@ func toRFC1123(s string, maxlen int) string {
 	s = nonAlphanumerics.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-")
 
-	// 253 characters is the maximum length for an RFC1123 resource name in Kubernetes
 	if len(s) > maxlen {
 		s = s[:maxlen]
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,96 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestToRFC1123 tests the toRFC1123 function with various input cases to ensure it correctly converts
+// strings to RFC 1123 compliant format.
+func TestToRFC1123(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid input",
+			input:    "my-iut",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with uppercase letters",
+			input:    "My-IUT",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with invalid characters",
+			input:    "my_@#%&*()Iut!",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with leading and trailing hyphens",
+			input:    "-my-iut-",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with multiple spaces",
+			input:    "my   iut",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with invalid character at end",
+			input:    "my-iut!",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with invalid character at start",
+			input:    "@my-iut",
+			expected: "my-iut",
+		},
+		{
+			name:     "input with mixed case",
+			input:    "MyIUTName",
+			expected: "myiutname",
+		},
+		{
+			name:     "input exceeding 253 characters",
+			input:    strings.Repeat("a", 255),
+			expected: strings.Repeat("a", 253),
+		},
+		{
+			name:     "input single word",
+			input:    "iut",
+			expected: "iut",
+		},
+		{
+			name:     "input with only numbers",
+			input:    "123",
+			expected: "123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toRFC1123(tt.input)
+			if result != tt.expected {
+				t.Errorf("toRFC1123(%q) = %q; expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -87,7 +87,7 @@ func TestToRFC1123(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := toRFC1123(tt.input)
+			result := toRFC1123(tt.input, 253)
 			if result != tt.expected {
 				t.Errorf("toRFC1123(%q) = %q; expected %q", tt.input, result, tt.expected)
 			}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -35,7 +35,7 @@ func TestToRFC1123(t *testing.T) {
 		},
 		{
 			name:     "input with uppercase letters",
-			input:    "My-IUT",
+			input:    "My----IUT",
 			expected: "my-iut",
 		},
 		{
@@ -45,7 +45,7 @@ func TestToRFC1123(t *testing.T) {
 		},
 		{
 			name:     "input with leading and trailing hyphens",
-			input:    "-my-iut-",
+			input:    "-my-iut--",
 			expected: "my-iut",
 		},
 		{
@@ -69,9 +69,9 @@ func TestToRFC1123(t *testing.T) {
 			expected: "myiutname",
 		},
 		{
-			name:     "input exceeding 253 characters",
-			input:    strings.Repeat("a", 255),
-			expected: strings.Repeat("a", 253),
+			name:     "input exceeding 63 characters",
+			input:    strings.Repeat("a", 65),
+			expected: strings.Repeat("a", 63),
 		},
 		{
 			name:     "input single word",
@@ -87,7 +87,7 @@ func TestToRFC1123(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := toRFC1123(tt.input, 253)
+			result := toRFC1123(tt.input, 63)
 			if result != tt.expected {
 				t.Errorf("toRFC1123(%q) = %q; expected %q", tt.input, result, tt.expected)
 			}


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
fixes: #642 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Convert generated names to be rfc1123 dns subdomain compatible.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I decided against always converting the name and only converting it if it is generated by the provider package.
Providers that pass a name must handle this themselves.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
~~If the name exceeds 253 characters then we will trim away the `-iut`, `-log-area` and `-execution-space` suffixes. We don't really need to suffix the resources with it since it should already be obvious that an `Iut` resource is an `iut`.~~
Removed suffix

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
