### PR TITLE
Add Timeout and Deadline fields to TestRun CRD

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -126,6 +126,20 @@ type TestRunSpec struct {
 	// It is used to set batchesUri in the TERCC event.
 	// +optional
 	SuiteSource string `json:"suiteSource,omitempty"`
+
+	// Timeout is the maximum duration, in seconds, the testrun is allowed to take.
+	// If not set, defaults to 86400 (24 hours). If both Timeout and Deadline are set,
+	// Deadline takes precedence.
+	// +optional
+	// +kubebuilder:default=86400
+	Timeout int64 `json:"timeout,omitempty"`
+
+	// Deadline is the timestamp, in unix epoch seconds, by which the testrun
+	// must have completed. If the deadline is exceeded, the controller will fail
+	// the testrun. If not set, it is computed from Timeout at the start of the testrun.
+	// If both Timeout and Deadline are set, Deadline takes precedence.
+	// +optional
+	Deadline int64 `json:"deadline,omitempty"`
 }
 
 // TestRunStatus defines the observed state of TestRun

--- a/config/crd/bases/etos.eiffel-community.github.io_testruns.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_testruns.yaml
@@ -69,6 +69,14 @@ spec:
               cluster:
                 description: Name of the ETOS cluster to execute the testrun in.
                 type: string
+              deadline:
+                description: |-
+                  Deadline is the timestamp, in unix epoch seconds, by which the testrun
+                  must have completed. If the deadline is exceeded, the controller will fail
+                  the testrun. If not set, it is computed from Timeout at the start of the testrun.
+                  If both Timeout and Deadline are set, Deadline takes precedence.
+                format: int64
+                type: integer
               environmentProvider:
                 properties:
                   image:
@@ -230,6 +238,14 @@ spec:
                 required:
                 - version
                 type: object
+              timeout:
+                default: 86400
+                description: |-
+                  Timeout is the maximum duration, in seconds, the testrun is allowed to take.
+                  If not set, defaults to 86400 (24 hours). If both Timeout and Deadline are set,
+                  Deadline takes precedence.
+                format: int64
+                type: integer
             required:
             - artifact
             - identity

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -152,19 +152,6 @@ func (r *TestRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Compute deadline from timeout if not explicitly set.
-	// This runs once: after the deadline is persisted it won't be recomputed.
-	if testrun.Spec.Deadline == 0 {
-		timeout := testrun.Spec.Timeout
-		if timeout <= 0 {
-			timeout = 86400
-		}
-		testrun.Spec.Deadline = r.Now().Unix() + timeout
-		if err := r.Update(ctx, testrun); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Check deadline and fail the testrun if exceeded.
 	if testrun.Spec.Deadline != 0 {
 		convertedDeadline := time.Unix(testrun.Spec.Deadline, 0)

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -152,6 +152,39 @@ func (r *TestRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// Compute deadline from timeout if not explicitly set.
+	// This runs once: after the deadline is persisted it won't be recomputed.
+	if testrun.Spec.Deadline == 0 {
+		timeout := testrun.Spec.Timeout
+		if timeout <= 0 {
+			timeout = 86400
+		}
+		testrun.Spec.Deadline = r.Now().Unix() + timeout
+		if err := r.Update(ctx, testrun); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Check deadline and fail the testrun if exceeded.
+	if testrun.Spec.Deadline != 0 {
+		convertedDeadline := time.Unix(testrun.Spec.Deadline, 0)
+		if r.Now().After(convertedDeadline) {
+			logger.Info("Testrun deadline exceeded", "deadline", convertedDeadline)
+			if meta.SetStatusCondition(&testrun.Status.Conditions, metav1.Condition{
+				Type:    status.StatusActive,
+				Status:  metav1.ConditionFalse,
+				Reason:  status.ReasonTimedOut,
+				Message: fmt.Sprintf("Testrun deadline of %s exceeded", convertedDeadline),
+			}) {
+				now := metav1.Now()
+				testrun.Status.CompletionTime = &now
+				return ctrl.Result{}, r.Status().Update(ctx, testrun)
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{RequeueAfter: time.Until(convertedDeadline)}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/webhook/v1alpha1/testrun_webhook.go
+++ b/internal/webhook/v1alpha1/testrun_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -147,6 +148,12 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 		testrunlog.Info("Adding ETOS test run ID label", "id", testrun.Spec.ID)
 		testrun.Labels["etos.eiffel-community.github.io/id"] = testrun.Spec.ID
 	}
+
+	// Compute deadline from timeout if not explicitly set.
+	if testrun.Spec.Deadline == 0 {
+		testrun.Spec.Deadline = time.Now().Unix() + testrun.Spec.Timeout
+	}
+
 	testrunlog.Info("Defaulting webhook has finished")
 
 	return nil


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/644

### Description of the Change

Add Timeout (default 86400s) and Deadline (unix epoch) fields to TestRunSpec, matching the EnvironmentRequest pattern. If Deadline is not set, the controller computes it as Now + Timeout on the first reconcile and persists it. When the deadline is exceeded the controller fails the testrun with DeadlineExceeded. If both are set, Deadline takes precedence.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com