### PR TITLE
Add timeout and deadline support to ETOS client v1alpha

### DIFF
--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -76,5 +76,3 @@ class RequestSchema(BaseModel):
         if len(dataset) == 1:
             return json.loads(dataset[0])
         return [json.loads(data) for data in dataset]
-
-

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -19,7 +19,7 @@ import json
 from typing import Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ValidationInfo, field_validator
+from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
 
 class RequestSchema(BaseModel):
@@ -33,6 +33,8 @@ class RequestSchema(BaseModel):
     execution_space_provider: Optional[str] = "default"
     iut_provider: Optional[str] = "default"
     log_area_provider: Optional[str] = "default"
+    timeout: Optional[int] = None
+    deadline: Optional[int] = None
 
     @classmethod
     def from_args(cls, args: dict) -> "RequestSchema":
@@ -74,3 +76,26 @@ class RequestSchema(BaseModel):
         if len(dataset) == 1:
             return json.loads(dataset[0])
         return [json.loads(data) for data in dataset]
+
+    @model_validator(mode="after")
+    def extract_timeout_and_deadline_from_dataset(self) -> "RequestSchema":
+        """Extract timeout and deadline from dataset dicts and set them as top-level fields.
+
+        The timeout and deadline keys are removed from the dataset dicts so they
+        are not forwarded to the environment provider. Only one of timeout or
+        deadline may be set.
+
+        :return: The validated model.
+        :rtype: RequestSchema
+        """
+        # dataset_list_trimming may return a dict (single dataset) or list[dict]
+        items = self.dataset if isinstance(self.dataset, list) else [self.dataset]
+        for data in items:
+            if isinstance(data, dict):
+                if "timeout" in data:
+                    self.timeout = int(data.pop("timeout"))
+                if "deadline" in data:
+                    self.deadline = int(data.pop("deadline"))
+        if self.timeout is not None and self.deadline is not None:
+            raise ValueError("Only one of 'timeout' or 'deadline' can be set, not both.")
+        return self

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -22,6 +22,13 @@ from uuid import UUID
 from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
 
+def _parse_optional_int(value: object) -> Optional[int]:
+    """Parse a value to an optional int, returning None for falsy values."""
+    if value is None or value is False:
+        return None
+    return int(value)
+
+
 class RequestSchema(BaseModel):
     """Schema for ETOSv1 API requests."""
 
@@ -48,6 +55,8 @@ class RequestSchema(BaseModel):
             execution_space_provider=args["--execution-space-provider"] or "default",
             iut_provider=args["--iut-provider"] or "default",
             log_area_provider=args["--log-area-provider"] or "default",
+            timeout=_parse_optional_int(args.get("--timeout")),
+            deadline=_parse_optional_int(args.get("--deadline")),
         )
 
     @field_validator("artifact_identity")
@@ -78,24 +87,15 @@ class RequestSchema(BaseModel):
         return [json.loads(data) for data in dataset]
 
     @model_validator(mode="after")
-    def extract_timeout_and_deadline_from_dataset(self) -> "RequestSchema":
-        """Extract timeout and deadline from dataset dicts and set them as top-level fields.
+    def validate_timeout_or_deadline(self) -> "RequestSchema":
+        """Validate that only one of timeout or deadline is set.
 
-        The timeout and deadline keys are removed from the dataset dicts so they
-        are not forwarded to the environment provider. Only one of timeout or
-        deadline may be set.
+        The controller will ignore timeout if deadline is set, so we should
+        prevent users from setting both to avoid confusion.
 
         :return: The validated model.
         :rtype: RequestSchema
         """
-        # dataset_list_trimming may return a dict (single dataset) or list[dict]
-        items = self.dataset if isinstance(self.dataset, list) else [self.dataset]
-        for data in items:
-            if isinstance(data, dict):
-                if "timeout" in data:
-                    self.timeout = int(data.pop("timeout"))
-                if "deadline" in data:
-                    self.deadline = int(data.pop("deadline"))
         if self.timeout is not None and self.deadline is not None:
             raise ValueError("Only one of 'timeout' or 'deadline' can be set, not both.")
         return self

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -19,14 +19,7 @@ import json
 from typing import Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
-
-
-def _parse_optional_int(value: object) -> Optional[int]:
-    """Parse a value to an optional int, returning None for falsy values."""
-    if value is None or value is False:
-        return None
-    return int(value)
+from pydantic import BaseModel, ValidationInfo, field_validator
 
 
 class RequestSchema(BaseModel):
@@ -41,7 +34,6 @@ class RequestSchema(BaseModel):
     iut_provider: Optional[str] = "default"
     log_area_provider: Optional[str] = "default"
     timeout: Optional[int] = None
-    deadline: Optional[int] = None
 
     @classmethod
     def from_args(cls, args: dict) -> "RequestSchema":
@@ -55,8 +47,7 @@ class RequestSchema(BaseModel):
             execution_space_provider=args["--execution-space-provider"] or "default",
             iut_provider=args["--iut-provider"] or "default",
             log_area_provider=args["--log-area-provider"] or "default",
-            timeout=_parse_optional_int(args.get("--timeout")),
-            deadline=_parse_optional_int(args.get("--deadline")),
+            timeout=args["--timeout"],
         )
 
     @field_validator("artifact_identity")
@@ -86,16 +77,4 @@ class RequestSchema(BaseModel):
             return json.loads(dataset[0])
         return [json.loads(data) for data in dataset]
 
-    @model_validator(mode="after")
-    def validate_timeout_or_deadline(self) -> "RequestSchema":
-        """Validate that only one of timeout or deadline is set.
 
-        The controller will ignore timeout if deadline is set, so we should
-        prevent users from setting both to avoid confusion.
-
-        :return: The validated model.
-        :rtype: RequestSchema
-        """
-        if self.timeout is not None and self.deadline is not None:
-            raise ValueError("Only one of 'timeout' or 'deadline' can be set, not both.")
-        return self

--- a/cli/src/etos_client/etos/v1alpha/subcommands/start.py
+++ b/cli/src/etos_client/etos/v1alpha/subcommands/start.py
@@ -52,6 +52,10 @@ class Start(SubCommand):
         --log-area-provider LOG_AREA_PROVIDER                     Which log area provider to use.
         --dataset DATASET                                         Additional dataset information to the environment provider.
                                                                   Check with your provider which information can be supplied.
+        --timeout TIMEOUT                                         Maximum duration in seconds the testrun is allowed to take.
+                                                                  Defaults to 86400 (24 hours) if neither timeout nor deadline is set.
+        --deadline DEADLINE                                       Unix epoch timestamp by which the testrun must have completed.
+                                                                  Cannot be used together with --timeout.
         --ssev2alpha                                              Use the v2alpha version of sse.
         --version                                                 Show program's version number and exit
     """

--- a/cli/src/etos_client/etos/v1alpha/subcommands/start.py
+++ b/cli/src/etos_client/etos/v1alpha/subcommands/start.py
@@ -53,9 +53,7 @@ class Start(SubCommand):
         --dataset DATASET                                         Additional dataset information to the environment provider.
                                                                   Check with your provider which information can be supplied.
         --timeout TIMEOUT                                         Maximum duration in seconds the testrun is allowed to take.
-                                                                  Defaults to 86400 (24 hours) if neither timeout nor deadline is set.
-        --deadline DEADLINE                                       Unix epoch timestamp by which the testrun must have completed.
-                                                                  Cannot be used together with --timeout.
+                                                                  Defaults to 86400 (24 hours) if not set.
         --ssev2alpha                                              Use the v2alpha version of sse.
         --version                                                 Show program's version number and exit
     """

--- a/cli/tests/test_v1alpha_request_schema.py
+++ b/cli/tests/test_v1alpha_request_schema.py
@@ -13,13 +13,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the v1alpha RequestSchema, specifically timeout/deadline extraction."""
-
-import json
+"""Tests for the v1alpha RequestSchema timeout/deadline support."""
 
 import pytest
 
 from etos_client.etos.v1alpha.schema.request import RequestSchema
+
+
+def _make_args(**overrides):
+    """Create a minimal args dict mimicking docopt output, allowing overrides."""
+    defaults = {
+        "--identity": "12345678-1234-4321-abcd-123456789abc",
+        "--parent-activity": None,
+        "--test-suite": "http://example.com/suite.yaml",
+        "--dataset": [],
+        "--execution-space-provider": "default",
+        "--iut-provider": "default",
+        "--log-area-provider": "default",
+        "--timeout": None,
+        "--deadline": None,
+    }
+    defaults.update(overrides)
+    return defaults
 
 
 def _make_request(**kwargs):
@@ -38,84 +53,59 @@ def _make_request(**kwargs):
     return RequestSchema(**defaults)
 
 
-class TestTimeoutDeadlineExtraction:
-    """Test that timeout and deadline are extracted from the dataset."""
+class TestTimeoutDeadlineFlags:
+    """Test that timeout and deadline CLI flags work correctly."""
 
-    def test_timeout_extracted_from_dataset(self):
-        """Test that timeout is extracted from dataset and set on the model."""
-        request = _make_request(dataset=[json.dumps({"timeout": 3600})])
+    def test_timeout_from_args(self):
+        """Test that --timeout flag is passed through from_args."""
+        args = _make_args(**{"--timeout": "3600"})
+        request = RequestSchema.from_args(args)
         assert request.timeout == 3600
         assert request.deadline is None
-        # timeout should be removed from the dataset dict
-        ds = request.dataset if isinstance(request.dataset, list) else [request.dataset]
-        for data in ds:
-            assert "timeout" not in data
 
-    def test_deadline_extracted_from_dataset(self):
-        """Test that deadline is extracted from dataset and set on the model."""
-        request = _make_request(dataset=[json.dumps({"deadline": 1749200000})])
+    def test_deadline_from_args(self):
+        """Test that --deadline flag is passed through from_args."""
+        args = _make_args(**{"--deadline": "1749200000"})
+        request = RequestSchema.from_args(args)
         assert request.deadline == 1749200000
         assert request.timeout is None
-        ds = request.dataset if isinstance(request.dataset, list) else [request.dataset]
-        for data in ds:
-            assert "deadline" not in data
 
     def test_timeout_and_deadline_raises(self):
         """Test that setting both timeout and deadline raises an error."""
         with pytest.raises(ValueError, match="Only one of 'timeout' or 'deadline'"):
-            _make_request(dataset=[json.dumps({"timeout": 3600, "deadline": 1749200000})])
+            _make_request(timeout=3600, deadline=1749200000)
 
-    def test_no_timeout_or_deadline(self):
-        """Test that neither timeout nor deadline is set when not in dataset."""
-        request = _make_request(dataset=[json.dumps({"some_key": "some_value"})])
+    def test_neither_timeout_nor_deadline(self):
+        """Test that neither is set when not provided."""
+        args = _make_args()
+        request = RequestSchema.from_args(args)
         assert request.timeout is None
         assert request.deadline is None
-
-    def test_timeout_with_other_dataset_keys(self):
-        """Test that other dataset keys are preserved when timeout is extracted."""
-        request = _make_request(
-            dataset=[json.dumps({"timeout": 7200, "pool": "mypool", "count": 2})]
-        )
-        assert request.timeout == 7200
-        # Single dataset element is stored as a dict after validation
-        ds = request.dataset if isinstance(request.dataset, dict) else request.dataset[0]
-        assert ds == {"pool": "mypool", "count": 2}
-
-    def test_empty_dataset(self):
-        """Test that empty dataset works with no timeout/deadline."""
-        request = _make_request(dataset=None)
-        assert request.timeout is None
-        assert request.deadline is None
-        assert request.dataset == [{}]
 
     def test_timeout_included_in_model_dump(self):
         """Test that timeout appears in model_dump for API requests."""
-        request = _make_request(dataset=[json.dumps({"timeout": 1800})])
+        request = _make_request(timeout=1800)
         dumped = request.model_dump()
         assert dumped["timeout"] == 1800
         assert dumped["deadline"] is None
 
     def test_deadline_included_in_model_dump(self):
         """Test that deadline appears in model_dump for API requests."""
-        request = _make_request(dataset=[json.dumps({"deadline": 1749200000})])
+        request = _make_request(deadline=1749200000)
         dumped = request.model_dump()
         assert dumped["deadline"] == 1749200000
         assert dumped["timeout"] is None
 
-    def test_timeout_as_string_is_cast_to_int(self):
-        """Test that a string timeout value is cast to int."""
-        request = _make_request(dataset=[json.dumps({"timeout": "3600"})])
-        assert request.timeout == 3600
-        assert isinstance(request.timeout, int)
+    def test_none_args_produce_none_fields(self):
+        """Test that None args (docopt default) result in None fields."""
+        args = _make_args(**{"--timeout": None, "--deadline": None})
+        request = RequestSchema.from_args(args)
+        assert request.timeout is None
+        assert request.deadline is None
 
-    def test_multiple_datasets_timeout_from_last(self):
-        """Test that timeout from the last dataset dict wins if present in multiple."""
-        request = _make_request(
-            dataset=[
-                json.dumps({"timeout": 100, "pool": "a"}),
-                json.dumps({"timeout": 200, "pool": "b"}),
-            ]
-        )
-        assert request.timeout == 200
-        for data in request.dataset:
-            assert "timeout" not in data
+    def test_false_args_produce_none_fields(self):
+        """Test that False args (docopt when flag not provided) result in None fields."""
+        args = _make_args(**{"--timeout": False, "--deadline": False})
+        request = RequestSchema.from_args(args)
+        assert request.timeout is None
+        assert request.deadline is None

--- a/cli/tests/test_v1alpha_request_schema.py
+++ b/cli/tests/test_v1alpha_request_schema.py
@@ -1,0 +1,121 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the v1alpha RequestSchema, specifically timeout/deadline extraction."""
+
+import json
+
+import pytest
+
+from etos_client.etos.v1alpha.schema.request import RequestSchema
+
+
+def _make_request(**kwargs):
+    """Create a RequestSchema with sensible defaults, allowing overrides."""
+    defaults = {
+        "artifact_id": "12345678-1234-4321-abcd-123456789abc",
+        "artifact_identity": "pkg:test/identity",
+        "parent_activity": None,
+        "test_suite_url": "http://example.com/suite.yaml",
+        "dataset": None,
+        "execution_space_provider": "default",
+        "iut_provider": "default",
+        "log_area_provider": "default",
+    }
+    defaults.update(kwargs)
+    return RequestSchema(**defaults)
+
+
+class TestTimeoutDeadlineExtraction:
+    """Test that timeout and deadline are extracted from the dataset."""
+
+    def test_timeout_extracted_from_dataset(self):
+        """Test that timeout is extracted from dataset and set on the model."""
+        request = _make_request(dataset=[json.dumps({"timeout": 3600})])
+        assert request.timeout == 3600
+        assert request.deadline is None
+        # timeout should be removed from the dataset dict
+        ds = request.dataset if isinstance(request.dataset, list) else [request.dataset]
+        for data in ds:
+            assert "timeout" not in data
+
+    def test_deadline_extracted_from_dataset(self):
+        """Test that deadline is extracted from dataset and set on the model."""
+        request = _make_request(dataset=[json.dumps({"deadline": 1749200000})])
+        assert request.deadline == 1749200000
+        assert request.timeout is None
+        ds = request.dataset if isinstance(request.dataset, list) else [request.dataset]
+        for data in ds:
+            assert "deadline" not in data
+
+    def test_timeout_and_deadline_raises(self):
+        """Test that setting both timeout and deadline raises an error."""
+        with pytest.raises(ValueError, match="Only one of 'timeout' or 'deadline'"):
+            _make_request(dataset=[json.dumps({"timeout": 3600, "deadline": 1749200000})])
+
+    def test_no_timeout_or_deadline(self):
+        """Test that neither timeout nor deadline is set when not in dataset."""
+        request = _make_request(dataset=[json.dumps({"some_key": "some_value"})])
+        assert request.timeout is None
+        assert request.deadline is None
+
+    def test_timeout_with_other_dataset_keys(self):
+        """Test that other dataset keys are preserved when timeout is extracted."""
+        request = _make_request(
+            dataset=[json.dumps({"timeout": 7200, "pool": "mypool", "count": 2})]
+        )
+        assert request.timeout == 7200
+        # Single dataset element is stored as a dict after validation
+        ds = request.dataset if isinstance(request.dataset, dict) else request.dataset[0]
+        assert ds == {"pool": "mypool", "count": 2}
+
+    def test_empty_dataset(self):
+        """Test that empty dataset works with no timeout/deadline."""
+        request = _make_request(dataset=None)
+        assert request.timeout is None
+        assert request.deadline is None
+        assert request.dataset == [{}]
+
+    def test_timeout_included_in_model_dump(self):
+        """Test that timeout appears in model_dump for API requests."""
+        request = _make_request(dataset=[json.dumps({"timeout": 1800})])
+        dumped = request.model_dump()
+        assert dumped["timeout"] == 1800
+        assert dumped["deadline"] is None
+
+    def test_deadline_included_in_model_dump(self):
+        """Test that deadline appears in model_dump for API requests."""
+        request = _make_request(dataset=[json.dumps({"deadline": 1749200000})])
+        dumped = request.model_dump()
+        assert dumped["deadline"] == 1749200000
+        assert dumped["timeout"] is None
+
+    def test_timeout_as_string_is_cast_to_int(self):
+        """Test that a string timeout value is cast to int."""
+        request = _make_request(dataset=[json.dumps({"timeout": "3600"})])
+        assert request.timeout == 3600
+        assert isinstance(request.timeout, int)
+
+    def test_multiple_datasets_timeout_from_last(self):
+        """Test that timeout from the last dataset dict wins if present in multiple."""
+        request = _make_request(
+            dataset=[
+                json.dumps({"timeout": 100, "pool": "a"}),
+                json.dumps({"timeout": 200, "pool": "b"}),
+            ]
+        )
+        assert request.timeout == 200
+        for data in request.dataset:
+            assert "timeout" not in data

--- a/cli/tests/test_v1alpha_request_schema.py
+++ b/cli/tests/test_v1alpha_request_schema.py
@@ -13,9 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the v1alpha RequestSchema timeout/deadline support."""
-
-import pytest
+"""Tests for the v1alpha RequestSchema timeout support."""
 
 from etos_client.etos.v1alpha.schema.request import RequestSchema
 
@@ -31,7 +29,6 @@ def _make_args(**overrides):
         "--iut-provider": "default",
         "--log-area-provider": "default",
         "--timeout": None,
-        "--deadline": None,
     }
     defaults.update(overrides)
     return defaults
@@ -53,59 +50,36 @@ def _make_request(**kwargs):
     return RequestSchema(**defaults)
 
 
-class TestTimeoutDeadlineFlags:
-    """Test that timeout and deadline CLI flags work correctly."""
+class TestTimeoutFlag:
+    """Test that timeout CLI flag works correctly."""
 
     def test_timeout_from_args(self):
         """Test that --timeout flag is passed through from_args."""
         args = _make_args(**{"--timeout": "3600"})
         request = RequestSchema.from_args(args)
         assert request.timeout == 3600
-        assert request.deadline is None
 
-    def test_deadline_from_args(self):
-        """Test that --deadline flag is passed through from_args."""
-        args = _make_args(**{"--deadline": "1749200000"})
-        request = RequestSchema.from_args(args)
-        assert request.deadline == 1749200000
-        assert request.timeout is None
-
-    def test_timeout_and_deadline_raises(self):
-        """Test that setting both timeout and deadline raises an error."""
-        with pytest.raises(ValueError, match="Only one of 'timeout' or 'deadline'"):
-            _make_request(timeout=3600, deadline=1749200000)
-
-    def test_neither_timeout_nor_deadline(self):
-        """Test that neither is set when not provided."""
+    def test_timeout_not_set(self):
+        """Test that timeout is None when not provided."""
         args = _make_args()
         request = RequestSchema.from_args(args)
         assert request.timeout is None
-        assert request.deadline is None
 
     def test_timeout_included_in_model_dump(self):
         """Test that timeout appears in model_dump for API requests."""
         request = _make_request(timeout=1800)
         dumped = request.model_dump()
         assert dumped["timeout"] == 1800
-        assert dumped["deadline"] is None
 
-    def test_deadline_included_in_model_dump(self):
-        """Test that deadline appears in model_dump for API requests."""
-        request = _make_request(deadline=1749200000)
+    def test_timeout_none_in_model_dump(self):
+        """Test that timeout is None in model_dump when not set."""
+        request = _make_request()
         dumped = request.model_dump()
-        assert dumped["deadline"] == 1749200000
         assert dumped["timeout"] is None
 
-    def test_none_args_produce_none_fields(self):
-        """Test that None args (docopt default) result in None fields."""
-        args = _make_args(**{"--timeout": None, "--deadline": None})
+    def test_timeout_string_converted_to_int(self):
+        """Test that pydantic converts a string timeout to int."""
+        args = _make_args(**{"--timeout": "7200"})
         request = RequestSchema.from_args(args)
-        assert request.timeout is None
-        assert request.deadline is None
-
-    def test_false_args_produce_none_fields(self):
-        """Test that False args (docopt when flag not provided) result in None fields."""
-        args = _make_args(**{"--timeout": False, "--deadline": False})
-        request = RequestSchema.from_args(args)
-        assert request.timeout is None
-        assert request.deadline is None
+        assert request.timeout == 7200
+        assert isinstance(request.timeout, int)


### PR DESCRIPTION
### Applicable Issues

Related to https://github.com/eiffel-community/etos/issues/644

### Description of the Change

Extract optional `timeout` (seconds) and `deadline` (unix epoch) fields from the
`--dataset` JSON argument in the v1alpha ETOS client and forward them as top-level
fields in the API request. Includes validation that only one of the two may be set.
The v0 client path is unchanged.

### Alternate Designs

Could have added dedicated `--timeout` / `--deadline` CLI arguments, but extracting
from the existing dataset parameter is simpler and consistent with how other
provider-specific options are passed.

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com