### PR TITLE
Reduce verbosity in the messaging package

### DIFF
--- a/internal/messaging/rabbitmq.go
+++ b/internal/messaging/rabbitmq.go
@@ -152,7 +152,7 @@ func (s *rabbitMQStreamPublisher) Start() error {
 			go func() {
 				for _, msgStatus := range messageStatus {
 					if msgStatus.IsConfirmed() {
-						s.logger.Info("Message confirmed")
+						s.logger.V(1).Info("Message confirmed")
 						s.unConfirmed.Done()
 					} else {
 						s.logger.Error(msgStatus.GetError(), "Unconfirmed message")
@@ -194,7 +194,7 @@ func (s *rabbitMQStreamPublisher) Publish(b []byte, filterString string) error {
 		"meta":       filter.Meta,
 	}
 	s.unConfirmedMessages <- msg
-	s.logger.Info("Message published to unconfirmed channel")
+	s.logger.V(1).Info("Message published to unconfirmed channel")
 	return nil
 }
 
@@ -203,13 +203,13 @@ func (s *rabbitMQStreamPublisher) publish(done chan struct{}) {
 	for {
 		select {
 		case msg := <-s.unConfirmedMessages:
-			s.logger.Info("Publishing message to RabbitMQ stream")
+			s.logger.V(1).Info("Publishing message to RabbitMQ stream")
 			if err := s.producer.Send(msg); err != nil {
 				s.logger.Error(err, "Failed to send message")
 				s.unConfirmed.Done()
 				continue
 			}
-			s.logger.Info("Published")
+			s.logger.V(1).Info("Published")
 		case <-done:
 			return
 		}


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Each message that is now a debug message would print on every single log message that needed to be published.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I could be convinced to just remove the logs instead of setting them to DEBUG.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
