### PR TITLE
Default providers in testrun webhook from labeled Provider CRDs

### DIFF
--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -122,6 +122,7 @@ type ProviderStatus struct {
 // Provider is the Schema for the providers API
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].message"
+// +kubebuilder:selectablefield:JSONPath=".spec.type"
 type Provider struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -30,9 +30,9 @@ class RequestSchema(BaseModel):
     parent_activity: Optional[str]
     test_suite_url: str
     dataset: Optional[Union[dict, list]] = {}
-    execution_space_provider: Optional[str] = ""
-    iut_provider: Optional[str] = ""
-    log_area_provider: Optional[str] = ""
+    execution_space_provider: Optional[str] = None
+    iut_provider: Optional[str] = None
+    log_area_provider: Optional[str] = None
     timeout: Optional[int] = None
 
     @classmethod
@@ -44,9 +44,9 @@ class RequestSchema(BaseModel):
             parent_activity=args["--parent-activity"] or None,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
-            execution_space_provider=args["--execution-space-provider"] or "",
-            iut_provider=args["--iut-provider"] or "",
-            log_area_provider=args["--log-area-provider"] or "",
+            execution_space_provider=args["--execution-space-provider"] or None,
+            iut_provider=args["--iut-provider"] or None,
+            log_area_provider=args["--log-area-provider"] or None,
             timeout=args["--timeout"],
         )
 

--- a/cli/src/etos_client/etos/v1alpha/schema/request.py
+++ b/cli/src/etos_client/etos/v1alpha/schema/request.py
@@ -30,9 +30,9 @@ class RequestSchema(BaseModel):
     parent_activity: Optional[str]
     test_suite_url: str
     dataset: Optional[Union[dict, list]] = {}
-    execution_space_provider: Optional[str] = "default"
-    iut_provider: Optional[str] = "default"
-    log_area_provider: Optional[str] = "default"
+    execution_space_provider: Optional[str] = ""
+    iut_provider: Optional[str] = ""
+    log_area_provider: Optional[str] = ""
     timeout: Optional[int] = None
 
     @classmethod
@@ -44,9 +44,9 @@ class RequestSchema(BaseModel):
             parent_activity=args["--parent-activity"] or None,
             test_suite_url=args["--test-suite"],
             dataset=args["--dataset"],
-            execution_space_provider=args["--execution-space-provider"] or "default",
-            iut_provider=args["--iut-provider"] or "default",
-            log_area_provider=args["--log-area-provider"] or "default",
+            execution_space_provider=args["--execution-space-provider"] or "",
+            iut_provider=args["--iut-provider"] or "",
+            log_area_provider=args["--log-area-provider"] or "",
             timeout=args["--timeout"],
         )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -294,6 +294,13 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := webhookv1alpha1.SetupProviderWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create webhook", "webhook", "Provider")
+			os.Exit(1)
+		}
+	}
 	if err := (&controller.IutReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/config/crd/bases/etos.eiffel-community.github.io_providers.yaml
+++ b/config/crd/bases/etos.eiffel-community.github.io_providers.yaml
@@ -526,6 +526,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.type
     served: true
     storage: true
     subresources:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -136,6 +136,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-etos-eiffel-community-github-io-v1alpha1-provider
+  failurePolicy: Fail
+  name: vprovider-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - etos.eiffel-community.github.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - providers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-etos-eiffel-community-github-io-v1alpha1-testrun
   failurePolicy: Fail
   name: vtestrun-v1alpha1.kb.io

--- a/internal/webhook/v1alpha1/provider_webhook.go
+++ b/internal/webhook/v1alpha1/provider_webhook.go
@@ -92,19 +92,17 @@ func (v *ProviderCustomValidator) validateDefaultLabel(ctx context.Context, prov
 		if p.Name == provider.Name && p.Namespace == provider.Namespace {
 			continue
 		}
-		{
-			var allErrs field.ErrorList
-			allErrs = append(allErrs, field.Invalid(
-				field.NewPath("metadata").Child("labels").Key("etos.eiffel-community.github.io/default"),
-				"true",
-				fmt.Sprintf("a default provider of type %q already exists in this namespace: %q", provider.Spec.Type, p.Name),
-			))
-			groupVersionKind := provider.GroupVersionKind()
-			return apierrors.NewInvalid(
-				schema.GroupKind{Group: groupVersionKind.Group, Kind: groupVersionKind.Kind},
-				provider.Name, allErrs,
-			)
-		}
+		var allErrs field.ErrorList
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("metadata").Child("labels").Key("etos.eiffel-community.github.io/default"),
+			"true",
+			fmt.Sprintf("a default provider of type %q already exists in this namespace: %q", provider.Spec.Type, p.Name),
+		))
+		groupVersionKind := provider.GroupVersionKind()
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: groupVersionKind.Group, Kind: groupVersionKind.Kind},
+			provider.Name, allErrs,
+		)
 	}
 	return nil
 }

--- a/internal/webhook/v1alpha1/provider_webhook.go
+++ b/internal/webhook/v1alpha1/provider_webhook.go
@@ -35,8 +35,11 @@ var providerlog = logf.Log.WithName("provider-resource")
 
 // SetupProviderWebhookWithManager registers the webhook for Provider in the manager.
 func SetupProviderWebhookWithManager(mgr ctrl.Manager) error {
+	if cli == nil {
+		cli = mgr.GetClient()
+	}
 	return ctrl.NewWebhookManagedBy(mgr, &etosv1alpha1.Provider{}).
-		WithValidator(&ProviderCustomValidator{mgr.GetClient()}).
+		WithValidator(&ProviderCustomValidator{}).
 		Complete()
 }
 
@@ -47,9 +50,7 @@ func SetupProviderWebhookWithManager(mgr ctrl.Manager) error {
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type ProviderCustomValidator struct {
-	client client.Client
-}
+type ProviderCustomValidator struct{}
 
 // ValidateCreate validates the creation of a Provider.
 func (v *ProviderCustomValidator) ValidateCreate(ctx context.Context, provider *etosv1alpha1.Provider) (admission.Warnings, error) {
@@ -76,11 +77,12 @@ func (v *ProviderCustomValidator) validateDefaultLabel(ctx context.Context, prov
 		return nil
 	}
 
-	// List all providers in the namespace that are labeled as default.
+	// List all default providers of the same type in the namespace.
 	providers := &etosv1alpha1.ProviderList{}
-	if err := v.client.List(ctx, providers,
+	if err := cli.List(ctx, providers,
 		client.InNamespace(provider.Namespace),
 		client.MatchingLabels{"etos.eiffel-community.github.io/default": "true"},
+		client.MatchingFields{".spec.type": provider.Spec.Type},
 	); err != nil {
 		return fmt.Errorf("failed to list providers: %w", err)
 	}
@@ -90,7 +92,7 @@ func (v *ProviderCustomValidator) validateDefaultLabel(ctx context.Context, prov
 		if p.Name == provider.Name && p.Namespace == provider.Namespace {
 			continue
 		}
-		if p.Spec.Type == provider.Spec.Type {
+		{
 			var allErrs field.ErrorList
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("metadata").Child("labels").Key("etos.eiffel-community.github.io/default"),

--- a/internal/webhook/v1alpha1/provider_webhook.go
+++ b/internal/webhook/v1alpha1/provider_webhook.go
@@ -1,0 +1,108 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	etosv1alpha1 "github.com/eiffel-community/etos/api/v1alpha1"
+)
+
+var providerlog = logf.Log.WithName("provider-resource")
+
+// SetupProviderWebhookWithManager registers the webhook for Provider in the manager.
+func SetupProviderWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &etosv1alpha1.Provider{}).
+		WithValidator(&ProviderCustomValidator{mgr.GetClient()}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-etos-eiffel-community-github-io-v1alpha1-provider,mutating=false,failurePolicy=fail,sideEffects=None,groups=etos.eiffel-community.github.io,resources=providers,verbs=create;update,versions=v1alpha1,name=vprovider-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// ProviderCustomValidator struct is responsible for validating the Provider resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type ProviderCustomValidator struct {
+	client client.Client
+}
+
+// ValidateCreate validates the creation of a Provider.
+func (v *ProviderCustomValidator) ValidateCreate(ctx context.Context, provider *etosv1alpha1.Provider) (admission.Warnings, error) {
+	providerlog.Info("Validation for Provider upon creation", "name", provider.GetName())
+	return nil, v.validateDefaultLabel(ctx, provider)
+}
+
+// ValidateUpdate validates the update of a Provider.
+func (v *ProviderCustomValidator) ValidateUpdate(ctx context.Context, _, provider *etosv1alpha1.Provider) (admission.Warnings, error) {
+	providerlog.Info("Validation for Provider upon update", "name", provider.GetName())
+	return nil, v.validateDefaultLabel(ctx, provider)
+}
+
+// ValidateDelete validates the deletion of a Provider.
+func (v *ProviderCustomValidator) ValidateDelete(_ context.Context, _ *etosv1alpha1.Provider) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateDefaultLabel ensures that at most one provider per type is labeled as default
+// within the same namespace.
+func (v *ProviderCustomValidator) validateDefaultLabel(ctx context.Context, provider *etosv1alpha1.Provider) error {
+	// Only validate if this provider is being marked as default.
+	if provider.Labels == nil || provider.Labels["etos.eiffel-community.github.io/default"] != "true" {
+		return nil
+	}
+
+	// List all providers in the namespace that are labeled as default.
+	providers := &etosv1alpha1.ProviderList{}
+	if err := v.client.List(ctx, providers,
+		client.InNamespace(provider.Namespace),
+		client.MatchingLabels{"etos.eiffel-community.github.io/default": "true"},
+	); err != nil {
+		return fmt.Errorf("failed to list providers: %w", err)
+	}
+
+	for _, p := range providers.Items {
+		// Skip self (relevant for updates).
+		if p.Name == provider.Name && p.Namespace == provider.Namespace {
+			continue
+		}
+		if p.Spec.Type == provider.Spec.Type {
+			var allErrs field.ErrorList
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("metadata").Child("labels").Key("etos.eiffel-community.github.io/default"),
+				"true",
+				fmt.Sprintf("a default provider of type %q already exists in this namespace: %q", provider.Spec.Type, p.Name),
+			))
+			groupVersionKind := provider.GroupVersionKind()
+			return apierrors.NewInvalid(
+				schema.GroupKind{Group: groupVersionKind.Group, Kind: groupVersionKind.Kind},
+				provider.Name, allErrs,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/webhook/v1alpha1/testrun_webhook.go
+++ b/internal/webhook/v1alpha1/testrun_webhook.go
@@ -199,15 +199,14 @@ func findDefaultProvider(ctx context.Context, namespace, providerType string) (s
 	if err := cli.List(ctx, providers,
 		client.InNamespace(namespace),
 		client.MatchingLabels{"etos.eiffel-community.github.io/default": "true"},
+		client.MatchingFields{".spec.type": providerType},
 	); err != nil {
 		return "", fmt.Errorf("failed to list providers: %w", err)
 	}
-	for _, p := range providers.Items {
-		if p.Spec.Type == providerType {
-			return p.Name, nil
-		}
+	if len(providers.Items) == 0 {
+		return "", fmt.Errorf("no default provider of type %q found in namespace %q", providerType, namespace)
 	}
-	return "", fmt.Errorf("no default provider of type %q found in namespace %q", providerType, namespace)
+	return providers.Items[0].Name, nil
 }
 
 // +kubebuilder:webhook:path=/validate-etos-eiffel-community-github-io-v1alpha1-testrun,mutating=false,failurePolicy=fail,sideEffects=None,groups=etos.eiffel-community.github.io,resources=testruns,verbs=create;update,versions=v1alpha1,name=vtestrun-v1alpha1.kb.io,admissionReviewVersions=v1

--- a/internal/webhook/v1alpha1/testrun_webhook.go
+++ b/internal/webhook/v1alpha1/testrun_webhook.go
@@ -40,10 +40,6 @@ import (
 var testrunlog = logf.Log.WithName("testrun-resource")
 var cli client.Client
 
-// defaultProviderName is the sentinel value used by clients to indicate that the
-// webhook should resolve the actual default provider from labeled Provider CRDs.
-const defaultProviderName = "default"
-
 // SetupTestRunWebhookWithManager registers the webhook for TestRun in the manager.
 func SetupTestRunWebhookWithManager(mgr ctrl.Manager, cfg config.Config) error {
 	if cli == nil {
@@ -156,8 +152,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 	}
 
 	// Default providers from those labeled as default in the namespace.
-	// Providers set to empty or the special value "default" trigger a lookup.
-	if testrun.Spec.Providers.IUT == "" || testrun.Spec.Providers.IUT == defaultProviderName {
+	if testrun.Spec.Providers.IUT == "" {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "iut"); err != nil {
 			testrunlog.Error(err, "Failed to find default IUT provider")
 		} else {
@@ -165,7 +160,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 			testrun.Spec.Providers.IUT = name
 		}
 	}
-	if testrun.Spec.Providers.ExecutionSpace == "" || testrun.Spec.Providers.ExecutionSpace == defaultProviderName {
+	if testrun.Spec.Providers.ExecutionSpace == "" {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "execution-space"); err != nil {
 			testrunlog.Error(err, "Failed to find default execution space provider")
 		} else {
@@ -173,7 +168,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 			testrun.Spec.Providers.ExecutionSpace = name
 		}
 	}
-	if testrun.Spec.Providers.LogArea == "" || testrun.Spec.Providers.LogArea == defaultProviderName {
+	if testrun.Spec.Providers.LogArea == "" {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "log-area"); err != nil {
 			testrunlog.Error(err, "Failed to find default log area provider")
 		} else {

--- a/internal/webhook/v1alpha1/testrun_webhook.go
+++ b/internal/webhook/v1alpha1/testrun_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -150,6 +151,33 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 		testrun.Labels["etos.eiffel-community.github.io/id"] = testrun.Spec.ID
 	}
 
+	// Default providers from those labeled as default in the namespace.
+	// Providers set to empty or the special value "default" trigger a lookup.
+	if testrun.Spec.Providers.IUT == "" || testrun.Spec.Providers.IUT == "default" {
+		if name, err := findDefaultProvider(ctx, testrun.Namespace, "iut"); err != nil {
+			testrunlog.Error(err, "Failed to find default IUT provider")
+		} else {
+			testrunlog.Info("Defaulting IUT provider", "provider", name)
+			testrun.Spec.Providers.IUT = name
+		}
+	}
+	if testrun.Spec.Providers.ExecutionSpace == "" || testrun.Spec.Providers.ExecutionSpace == "default" {
+		if name, err := findDefaultProvider(ctx, testrun.Namespace, "execution-space"); err != nil {
+			testrunlog.Error(err, "Failed to find default execution space provider")
+		} else {
+			testrunlog.Info("Defaulting execution space provider", "provider", name)
+			testrun.Spec.Providers.ExecutionSpace = name
+		}
+	}
+	if testrun.Spec.Providers.LogArea == "" || testrun.Spec.Providers.LogArea == "default" {
+		if name, err := findDefaultProvider(ctx, testrun.Namespace, "log-area"); err != nil {
+			testrunlog.Error(err, "Failed to find default log area provider")
+		} else {
+			testrunlog.Info("Defaulting log area provider", "provider", name)
+			testrun.Spec.Providers.LogArea = name
+		}
+	}
+
 	// Compute deadline from timeout if not explicitly set.
 	if testrun.Spec.Deadline == 0 {
 		testrun.Spec.Deadline = time.Now().Unix() + testrun.Spec.Timeout
@@ -158,6 +186,24 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 	testrunlog.Info("Defaulting webhook has finished")
 
 	return nil
+}
+
+// findDefaultProvider finds a provider of the given type that is labeled as the default
+// in the specified namespace. Returns the provider name or an error if none is found.
+func findDefaultProvider(ctx context.Context, namespace, providerType string) (string, error) {
+	providers := &etosv1alpha1.ProviderList{}
+	if err := cli.List(ctx, providers,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"etos.eiffel-community.github.io/default": "true"},
+	); err != nil {
+		return "", fmt.Errorf("failed to list providers: %w", err)
+	}
+	for _, p := range providers.Items {
+		if p.Spec.Type == providerType {
+			return p.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no default provider of type %q found in namespace %q", providerType, namespace)
 }
 
 // +kubebuilder:webhook:path=/validate-etos-eiffel-community-github-io-v1alpha1-testrun,mutating=false,failurePolicy=fail,sideEffects=None,groups=etos.eiffel-community.github.io,resources=testruns,verbs=create;update,versions=v1alpha1,name=vtestrun-v1alpha1.kb.io,admissionReviewVersions=v1
@@ -210,6 +256,28 @@ func (d *TestRunCustomValidator) validate(testrun *etosv1alpha1.TestRun) error {
 			field.NewPath("spec").Child("testRunner"),
 			testrun.Spec.TestRunner,
 			"TestRunner version information is missing, maybe because cluster is missing?",
+		))
+	}
+
+	if testrun.Spec.Providers.IUT == "" {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec").Child("providers").Child("iut"),
+			testrun.Spec.Providers.IUT,
+			"IUT provider is missing, either specify it explicitly or ensure a default provider (labeled etos.eiffel-community.github.io/default=true) of type 'iut' exists in the namespace",
+		))
+	}
+	if testrun.Spec.Providers.ExecutionSpace == "" {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec").Child("providers").Child("executionSpace"),
+			testrun.Spec.Providers.ExecutionSpace,
+			"Execution space provider is missing, either specify it explicitly or ensure a default provider (labeled etos.eiffel-community.github.io/default=true) of type 'execution-space' exists in the namespace",
+		))
+	}
+	if testrun.Spec.Providers.LogArea == "" {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec").Child("providers").Child("logArea"),
+			testrun.Spec.Providers.LogArea,
+			"Log area provider is missing, either specify it explicitly or ensure a default provider (labeled etos.eiffel-community.github.io/default=true) of type 'log-area' exists in the namespace",
 		))
 	}
 

--- a/internal/webhook/v1alpha1/testrun_webhook.go
+++ b/internal/webhook/v1alpha1/testrun_webhook.go
@@ -40,6 +40,10 @@ import (
 var testrunlog = logf.Log.WithName("testrun-resource")
 var cli client.Client
 
+// defaultProviderName is the sentinel value used by clients to indicate that the
+// webhook should resolve the actual default provider from labeled Provider CRDs.
+const defaultProviderName = "default"
+
 // SetupTestRunWebhookWithManager registers the webhook for TestRun in the manager.
 func SetupTestRunWebhookWithManager(mgr ctrl.Manager, cfg config.Config) error {
 	if cli == nil {
@@ -153,7 +157,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 
 	// Default providers from those labeled as default in the namespace.
 	// Providers set to empty or the special value "default" trigger a lookup.
-	if testrun.Spec.Providers.IUT == "" || testrun.Spec.Providers.IUT == "default" {
+	if testrun.Spec.Providers.IUT == "" || testrun.Spec.Providers.IUT == defaultProviderName {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "iut"); err != nil {
 			testrunlog.Error(err, "Failed to find default IUT provider")
 		} else {
@@ -161,7 +165,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 			testrun.Spec.Providers.IUT = name
 		}
 	}
-	if testrun.Spec.Providers.ExecutionSpace == "" || testrun.Spec.Providers.ExecutionSpace == "default" {
+	if testrun.Spec.Providers.ExecutionSpace == "" || testrun.Spec.Providers.ExecutionSpace == defaultProviderName {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "execution-space"); err != nil {
 			testrunlog.Error(err, "Failed to find default execution space provider")
 		} else {
@@ -169,7 +173,7 @@ func (d *TestRunCustomDefaulter) Default(ctx context.Context, testrun *etosv1alp
 			testrun.Spec.Providers.ExecutionSpace = name
 		}
 	}
-	if testrun.Spec.Providers.LogArea == "" || testrun.Spec.Providers.LogArea == "default" {
+	if testrun.Spec.Providers.LogArea == "" || testrun.Spec.Providers.LogArea == defaultProviderName {
 		if name, err := findDefaultProvider(ctx, testrun.Namespace, "log-area"); err != nil {
 			testrunlog.Error(err, "Failed to find default log area provider")
 		} else {

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -117,10 +117,10 @@ var _ = BeforeSuite(func() {
 	err = SetupEnvironmentRequestWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-err = SetupClusterWebhookWithManager(mgr)
-        Expect(err).NotTo(HaveOccurred())
+	err = SetupClusterWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
 
-        err = SetupProviderWebhookWithManager(mgr)
+	err = SetupProviderWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -117,7 +117,10 @@ var _ = BeforeSuite(func() {
 	err = SetupEnvironmentRequestWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupClusterWebhookWithManager(mgr)
+err = SetupClusterWebhookWithManager(mgr)
+        Expect(err).NotTo(HaveOccurred())
+
+        err = SetupProviderWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/669

### Description of the Change

The testrun defaulting webhook now resolves providers automatically when they are empty or set to "default". It looks up Provider CRDs labeled `etos.eiffel-community.github.io/default: "true"` matching the required type (iut, execution-space, log-area) in the namespace. The validating webhook also rejects testruns where providers could not be resolved.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com