### PR TITLE
Document TEST_FRAMEWORK_VENV in system engineer guide

### DIFF
--- a/docs/roles/system_engineer.md
+++ b/docs/roles/system_engineer.md
@@ -63,7 +63,7 @@ When building a custom test runner Docker image that installs a test framework i
 ENV TEST_FRAMEWORK_VENV=/home/etos/.test-framework
 ```
 
-If `TEST_FRAMEWORK_VENV` is not set, the test runner falls back to pyenv (if available) for backward compatibility with older base images.
+If `TEST_FRAMEWORK_VENV` is not set, the test runner falls back to pyenv (if available) for backward compatibility with older base images. If neither is available, tests run in the default ETR Python environment.
 
 #### LogArea
 

--- a/docs/roles/system_engineer.md
+++ b/docs/roles/system_engineer.md
@@ -55,6 +55,16 @@ There are three types of providers.
 Where the tests are executed, including deployed extra services required for the tests.
 The Execution space provider will prepare the environment for testing and start up the Test runner container which will install the ETOS test runner. This provider will also make sure all the environment variables are correctly set.
 
+##### Custom test runner images
+
+When building a custom test runner Docker image that installs a test framework into its own virtualenv (separate from the ETOS test runner virtualenv), set the `TEST_FRAMEWORK_VENV` environment variable to the path of that virtualenv. The ETOS test runner will activate it before running tests and checkout scripts.
+
+```Dockerfile
+ENV TEST_FRAMEWORK_VENV=/home/etos/.test-framework
+```
+
+If `TEST_FRAMEWORK_VENV` is not set, the test runner falls back to pyenv (if available) for backward compatibility with older base images.
+
 #### LogArea
 
 Where the test artifacts and logs are stored. The ETOS test runner uploads all files that are generated to a file storage server, this is the description of the file storage server and how to upload to it.


### PR DESCRIPTION
### Applicable Issues

eiffel-community/etos#672

### Description of the Change

Add documentation for the `TEST_FRAMEWORK_VENV` environment variable to the system engineer role guide. This variable is used when building custom test runner Docker images that install a test framework into a separate virtualenv.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com