### PR TITLE
Fix a problem with the connection hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.3
 require (
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611
 	github.com/go-logr/logr v1.4.3
+	github.com/gohugoio/hashstructure v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/gohugoio/hashstructure v0.6.0 h1:7wMB/2CfXoThFYhdWRGv3u3rUM761Cq29CxUW+NltUg=
+github.com/gohugoio/hashstructure v0.6.0/go.mod h1:lapVLk9XidheHG1IQ4ZSbyYrXcaILU1ZEP/+vno5rBQ=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=

--- a/internal/messaging/pool.go
+++ b/internal/messaging/pool.go
@@ -17,7 +17,6 @@ package messaging
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sync"
@@ -25,13 +24,27 @@ import (
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/pkg/messaging/events"
 	"github.com/go-logr/logr"
+	"github.com/gohugoio/hashstructure"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type EventPublisher interface {
+	Publish(string, events.Event) error
+	AddLogger(logr.Logger)
+	Close() error
+}
 
 type PublisherPool struct {
 	ctx        context.Context
 	publishers map[string]*Publisher
 	lock       sync.Mutex
+}
+
+// namespacedParameters is a struct that combines the RabbitMQ parameters with the
+// namespace to create a unique identifier for the connection.
+type namespacedParameters struct {
+	v1alpha1.RabbitMQ
+	Namespace string
 }
 
 // NewPublisherPool creates a new PublisherPool instance.
@@ -47,10 +60,12 @@ func (p *PublisherPool) GetPublisher(
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	// Hash the connection parameters and namespace to create a unique name for the connection
-	var hashInput []byte
-	hashInput = fmt.Appendf(hashInput, "%v", parameters)
-	hashInput = fmt.Append(hashInput, namespace)
-	name := fmt.Sprintf("%x", sha256.Sum256(hashInput))
+	namespacedParams := namespacedParameters{parameters, namespace}
+	hash, err := hashstructure.Hash(namespacedParams, nil)
+	if err != nil {
+		return nil, err
+	}
+	name := fmt.Sprintf("%x", hash)
 	publisher, exists := p.publishers[name]
 	if !exists {
 		if err := p.addPublisher(name, namespace, cli, parameters); err != nil {
@@ -66,7 +81,7 @@ func (p *PublisherPool) addPublisher(name, namespace string, cli client.Client, 
 	if _, exists := p.publishers[name]; exists {
 		return nil
 	}
-	publisher, err := NewRabbitMQStreamPublisher(p.ctx, "controller", parameters, cli, namespace)
+	publisher, err := publisherImpl(p.ctx, "controller", parameters, cli, namespace)
 	if err != nil {
 		return err
 	}
@@ -88,7 +103,7 @@ func (p *PublisherPool) Close() error {
 }
 
 type Publisher struct {
-	publisher *rabbitMQStreamPublisher
+	publisher EventPublisher
 }
 
 // Publish sends an event to the EventPublisher.
@@ -104,4 +119,17 @@ func (p Publisher) AddLogger(logger logr.Logger) {
 // Close closes the publisher's connection.
 func (p Publisher) Close() error {
 	return p.publisher.Close()
+}
+
+var publisherImpl = NewRabbitMQStreamPublisher
+
+// SetPublisherImpl allows overriding the default implementation of the publisher, which is useful for testing.
+func SetPublisherImpl(impl func(
+	ctx context.Context,
+	identifier string,
+	parameters v1alpha1.RabbitMQ,
+	cli client.Client,
+	namespace string,
+) (EventPublisher, error)) {
+	publisherImpl = impl
 }

--- a/internal/messaging/pool_test.go
+++ b/internal/messaging/pool_test.go
@@ -1,0 +1,204 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package messaging_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eiffel-community/etos/api/v1alpha1"
+	"github.com/eiffel-community/etos/internal/messaging"
+	"github.com/eiffel-community/etos/pkg/messaging/events"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestPoolReuseSameStruct tests that the PublisherPool reuses the same publisher when the
+// same struct is provided.
+func TestPoolReuseSameStruct(t *testing.T) {
+
+	messaging.SetPublisherImpl(func(
+		ctx context.Context,
+		identifier string,
+		parameters v1alpha1.RabbitMQ,
+		cli client.Client,
+		namespace string,
+	) (messaging.EventPublisher, error) {
+		return &mockPublisher{}, nil
+	})
+	pool := messaging.NewPublisherPool(context.Background())
+	cli := fake.NewClientBuilder().Build()
+
+	parameters := v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "password",
+		},
+	}
+	publisher, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create publisher: %v", err)
+	}
+
+	second, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create second publisher: %v", err)
+	}
+	if publisher != second {
+		t.Errorf("Expected to get the same publisher, but got different ones")
+	}
+}
+
+// TestPoolReuseSameParameters tests that the PublisherPool reuses the same publisher when the
+// same parameters are provided, even if they are different structs.
+func TestPoolReuseSameParameters(t *testing.T) {
+
+	messaging.SetPublisherImpl(func(
+		ctx context.Context,
+		identifier string,
+		parameters v1alpha1.RabbitMQ,
+		cli client.Client,
+		namespace string,
+	) (messaging.EventPublisher, error) {
+		return &mockPublisher{}, nil
+	})
+	pool := messaging.NewPublisherPool(context.Background())
+	cli := fake.NewClientBuilder().Build()
+
+	parameters := v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "password",
+		},
+	}
+	publisher, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create publisher: %v", err)
+	}
+
+	parameters = v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "password",
+		},
+	}
+	second, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create second publisher: %v", err)
+	}
+	if publisher != second {
+		t.Errorf("Expected to get the same publisher, but got different ones")
+	}
+}
+
+// TestPoolUseDifferentParameters tests that the PublisherPool creates a new publisher when different
+// parameters are provided.
+func TestPoolUseDifferentParameters(t *testing.T) {
+
+	messaging.SetPublisherImpl(func(
+		ctx context.Context,
+		identifier string,
+		parameters v1alpha1.RabbitMQ,
+		cli client.Client,
+		namespace string,
+	) (messaging.EventPublisher, error) {
+		return &mockPublisher{}, nil
+	})
+	pool := messaging.NewPublisherPool(context.Background())
+	cli := fake.NewClientBuilder().Build()
+
+	parameters := v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "password",
+		},
+	}
+	publisher, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create publisher: %v", err)
+	}
+
+	parameters = v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "differentpassword",
+		},
+	}
+	second, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create second publisher: %v", err)
+	}
+	if publisher == second {
+		t.Errorf("Expected to get different publishers, but got the same one")
+	}
+}
+
+// TestPoolUseDifferentNamespace tests that the PublisherPool creates a new publisher when different
+// namespaces are provided, even if the parameters are the same.
+// This test is the same as TestPoolUseDifferentParameters but since namespace is handled slightly
+// differently, it is good to have a separate test for it.
+func TestPoolUseDifferentNamespace(t *testing.T) {
+
+	messaging.SetPublisherImpl(func(
+		ctx context.Context,
+		identifier string,
+		parameters v1alpha1.RabbitMQ,
+		cli client.Client,
+		namespace string,
+	) (messaging.EventPublisher, error) {
+		return &mockPublisher{}, nil
+	})
+	pool := messaging.NewPublisherPool(context.Background())
+	cli := fake.NewClientBuilder().Build()
+
+	parameters := v1alpha1.RabbitMQ{
+		Host: "localhost",
+		Port: "5672",
+		Password: &v1alpha1.Var{
+			Value: "password",
+		},
+	}
+	publisher, err := pool.GetPublisher("test", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create publisher: %v", err)
+	}
+
+	second, err := pool.GetPublisher("differentnamespace", cli, parameters)
+	if err != nil {
+		t.Errorf("Failed to create second publisher: %v", err)
+	}
+	if publisher == second {
+		t.Errorf("Expected to get different publishers, but got the same one")
+	}
+}
+
+type mockPublisher struct{}
+
+func (m *mockPublisher) Publish(string, events.Event) error {
+	return nil
+}
+
+func (m *mockPublisher) AddLogger(logr.Logger) {}
+
+func (m *mockPublisher) Close() error {
+	return nil
+}

--- a/internal/messaging/rabbitmq.go
+++ b/internal/messaging/rabbitmq.go
@@ -67,7 +67,7 @@ func NewRabbitMQStreamPublisher(
 	config v1alpha1.RabbitMQ,
 	cli client.Client,
 	namespace string,
-) (*rabbitMQStreamPublisher, error) {
+) (EventPublisher, error) {
 	password, err := config.Password.Get(ctx, cli, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get RabbitMQ password: %w", err)

--- a/pkg/messaging/publisher/publisher.go
+++ b/pkg/messaging/publisher/publisher.go
@@ -25,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// EventPublisher is an interface that defines the methods for publishing events, adding a logger,
+// and closing the publisher connection.
 type EventPublisher interface {
-	Publish(string, events.Event) error
-	AddLogger(logr.Logger)
-	Close() error
+	messaging.EventPublisher
 }
 
 type Publisher struct {


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
This fix makes sure we don't create a new RabbitMQ connection on each reconcile of a testrun.
The hash would only be unique when using the same struct, not when using different structs (even though they had the same parameters). This fix uses an external package to do the hashing properly instead of us implementing our own.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
