### PR TITLE
Add field indexer for Provider .spec.type in webhook setup

### DIFF
--- a/internal/webhook/v1alpha1/provider_webhook.go
+++ b/internal/webhook/v1alpha1/provider_webhook.go
@@ -38,6 +38,13 @@ func SetupProviderWebhookWithManager(mgr ctrl.Manager) error {
 	if cli == nil {
 		cli = mgr.GetClient()
 	}
+	// Register a field index on .spec.type so that MatchingFields queries work in the webhook validators.
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &etosv1alpha1.Provider{}, ".spec.type", func(rawObj client.Object) []string {
+		provider := rawObj.(*etosv1alpha1.Provider)
+		return []string{provider.Spec.Type}
+	}); err != nil {
+		return err
+	}
 	return ctrl.NewWebhookManagedBy(mgr, &etosv1alpha1.Provider{}).
 		WithValidator(&ProviderCustomValidator{}).
 		Complete()


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/693

### Description of the Change

Register a field indexer for `.spec.type` on the Provider resource so that `client.MatchingFields` queries in the provider and testrun webhooks work correctly.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com