### PR TITLE
Separate generating a resource and creating it

### DIFF
--- a/cmd/executionspaceprovider/main.go
+++ b/cmd/executionspaceprovider/main.go
@@ -114,7 +114,7 @@ func (p *genericExecutionSpaceProvider) createExecutionSpaces(
 		)
 		environment["ENVIRONMENT_ID"] = id
 		environment["ENVIRONMENT_URL"] = fmt.Sprintf("%s/v1alpha/testrun/%s", cfg.EnvironmentRequest.Spec.Config.EtosApi, id)
-		executionSpace, err := provider.CreateExecutionSpace(ctx, cfg.EnvironmentRequest, cfg.Namespace, "",
+		executionSpace, err := provider.NewExecutionSpace(ctx, cfg.EnvironmentRequest, cfg.Namespace, "",
 			v1alpha2.ExecutionSpaceSpec{
 				ID:         id,
 				TestRunner: testrunner,
@@ -127,12 +127,17 @@ func (p *genericExecutionSpaceProvider) createExecutionSpaces(
 			})
 		if err != nil {
 			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to create ExecutionSpace")
+			span.SetStatus(codes.Error, "failed to create a ExecutionSpace")
+			return err
+		}
+		if err = executionSpace.Create(ctx); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "call to Kubernetes API to create ExecutionSpace failed")
 			return err
 		}
 		logger.Info(fmt.Sprintf("ExecutionSpace created with name '%s', launching ETOS test runner",
 			executionSpace.Name))
-		if err := p.start(ctx, cfg.EnvironmentRequest, executionSpace); err != nil {
+		if err := p.start(ctx, cfg.EnvironmentRequest, executionSpace.ExecutionSpace); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to start ETOS test runner")
 			return err

--- a/cmd/executionspaceprovider/main.go
+++ b/cmd/executionspaceprovider/main.go
@@ -127,7 +127,7 @@ func (p *genericExecutionSpaceProvider) createExecutionSpaces(
 			})
 		if err != nil {
 			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to create a ExecutionSpace")
+			span.SetStatus(codes.Error, "failed to create an ExecutionSpace")
 			return err
 		}
 		if err = executionSpace.Create(ctx); err != nil {

--- a/cmd/iutprovider/main.go
+++ b/cmd/iutprovider/main.go
@@ -67,10 +67,15 @@ func (p *genericIutProvider) createIUTs(ctx context.Context, cfg provider.Provis
 
 	for range cfg.MinimumAmount {
 		logger.Info("Creating a generic IUT")
-		iut, err := provider.CreateIUT(ctx, cfg.EnvironmentRequest, cfg.Namespace, "", v1alpha2.IutSpec{})
+		iut, err := provider.NewIUT(ctx, cfg.EnvironmentRequest, cfg.Namespace, "", v1alpha2.IutSpec{})
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create IUT")
+			return err
+		}
+		if err = iut.Create(ctx); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "call to Kubernetes API to create IUT failed")
 			return err
 		}
 		logger.Info(fmt.Sprintf("IUT created with name '%s'", iut.Name))

--- a/cmd/logareaprovider/main.go
+++ b/cmd/logareaprovider/main.go
@@ -94,7 +94,7 @@ func (p *genericLogAreaProvider) createLogAreas(
 	for range cfg.MinimumAmount {
 		logger.Info("Creating a generic LogArea")
 		logger.V(1).Info(fmt.Sprintf("Logs will be uploaded to %s", logAreaProvider.Spec.LogAreaProviderConfig.Upload.URL))
-		logarea, err := provider.CreateLogArea(ctx, cfg.EnvironmentRequest, cfg.Namespace, "", v1alpha2.LogAreaSpec{
+		logarea, err := provider.NewLogArea(ctx, cfg.EnvironmentRequest, cfg.Namespace, "", v1alpha2.LogAreaSpec{
 			LiveLogs: logAreaProvider.Spec.LogAreaProviderConfig.LiveLogs,
 			Logs:     map[string]string{},
 			Upload:   logAreaProvider.Spec.LogAreaProviderConfig.Upload,
@@ -102,6 +102,11 @@ func (p *genericLogAreaProvider) createLogAreas(
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create LogArea")
+			return err
+		}
+		if err = logarea.Create(ctx); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "call to Kubernetes API to create LogArea failed")
 			return err
 		}
 		logger.Info(fmt.Sprintf("LogArea created with name %s", logarea.Name))

--- a/pkg/provider/executionspace.go
+++ b/pkg/provider/executionspace.go
@@ -25,7 +25,6 @@ import (
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
 	"github.com/fernet/fernet-go"
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,27 +73,26 @@ func GetExecutionSpaces(
 	return executionSpaces, err
 }
 
-// CreateExecutionSpace creates a new ExecutionSpace resource in Kubernetes.
+type ExecutionSpace struct {
+	*v1alpha2.ExecutionSpace
+}
+
+// NewExecutionSpace creates a new ExecutionSpace.
 //
 // The spec.ProviderID and spec.EnvironmentRequest fields are automatically populated by this
 // function. It will be overwritten if set.
 // If a name is not provided, a name will be generated based on the EnvironmentRequest name.
 // If a name is provided it is the caller's responsibility to ensure name uniqueness, it will
 // not be guaranteed by this function.
-func CreateExecutionSpace(
+// To create the ExecutionSpace resource in Kubernetes, call the Create method on the returned struct.
+func NewExecutionSpace(
 	ctx context.Context,
 	environmentrequest *v1alpha1.EnvironmentRequest,
 	namespace, name string,
 	spec v1alpha2.ExecutionSpaceSpec,
-) (*v1alpha2.ExecutionSpace, error) {
-	logger := logr.FromContextOrDiscard(ctx)
+) (*ExecutionSpace, error) {
 	var executionSpace v1alpha2.ExecutionSpace
 
-	logger.Info("Getting Kubernetes client")
-	cli, err := KubernetesClient()
-	if err != nil {
-		return nil, err
-	}
 	environmentVariables, err := environmentVariables(ctx, environmentrequest)
 	if err != nil {
 		return nil, err
@@ -141,7 +139,16 @@ func CreateExecutionSpace(
 		Spec: spec,
 	}
 
-	return &executionSpace, cli.Create(ctx, &executionSpace)
+	return &ExecutionSpace{&executionSpace}, nil
+}
+
+// Create creates the ExecutionSpace resource in Kubernetes.
+func (e *ExecutionSpace) Create(ctx context.Context) error {
+	cli, err := KubernetesClient()
+	if err != nil {
+		return err
+	}
+	return cli.Create(ctx, e.ExecutionSpace)
 }
 
 // DeleteExecutionSpace deletes an ExecutionSpace resource from Kubernetes.

--- a/pkg/provider/iut.go
+++ b/pkg/provider/iut.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
-	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -80,27 +79,26 @@ func GetIUTs(ctx context.Context, environmentRequestID, namespace string) (v1alp
 	return iuts, err
 }
 
-// CreateIUT creates a new IUT resource in Kubernetes.
+type Iut struct {
+	*v1alpha2.Iut
+}
+
+// NewIUT creates a new IUT.
 //
 // The spec.ID, spec.Identity, spec.EnvironmentRequest, and spec.ProviderID fields are
 // automatically populated by this function. They will be overwritten if set.
 // If a name is not provided, a name will be generated based on the EnvironmentRequest name.
 // If a name is provided it is the caller's responsibility to ensure name uniqueness, it will
 // not be guaranteed by this function.
-func CreateIUT(
+// To create the IUT resource in Kubernetes, call the Create method on the returned struct.
+func NewIUT(
 	ctx context.Context,
 	environmentrequest *v1alpha1.EnvironmentRequest,
 	namespace, name string,
 	spec v1alpha2.IutSpec,
-) (*v1alpha2.Iut, error) {
-	logger := logr.FromContextOrDiscard(ctx)
+) (*Iut, error) {
 	var iut v1alpha2.Iut
 
-	logger.Info("Getting Kubernetes client")
-	cli, err := KubernetesClient()
-	if err != nil {
-		return nil, err
-	}
 	labels := map[string]string{
 		"app.kubernetes.io/name":    "iut-provider",
 		"app.kubernetes.io/part-of": "etos",
@@ -138,7 +136,16 @@ func CreateIUT(
 		Spec: spec,
 	}
 
-	return &iut, cli.Create(ctx, &iut)
+	return &Iut{&iut}, nil
+}
+
+// Create creates the IUT resource in Kubernetes.
+func (i *Iut) Create(ctx context.Context) error {
+	cli, err := KubernetesClient()
+	if err != nil {
+		return err
+	}
+	return cli.Create(ctx, i.Iut)
 }
 
 // DeleteIUT deletes an IUT resource from Kubernetes.

--- a/pkg/provider/logarea.go
+++ b/pkg/provider/logarea.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/eiffel-community/etos/api/v1alpha1"
 	"github.com/eiffel-community/etos/api/v1alpha2"
-	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -76,27 +75,26 @@ func GetLogAreas(
 	return logAreas, err
 }
 
-// CreateLogArea creates a new LogArea resource in Kubernetes.
+type LogArea struct {
+	*v1alpha2.LogArea
+}
+
+// NewLogArea creates a new LogArea.
 //
 // The spec.ID, spec.EnvironmentRequest, and spec.ProviderID fields are automatically populated
 // by this function. They will be overwritten if set.
 // If a name is not provided, a name will be generated based on the EnvironmentRequest name.
 // If a name is provided it is the caller's responsibility to ensure name uniqueness, it will
 // not be guaranteed by this function.
-func CreateLogArea(
+// To create the LogArea resource in Kubernetes, call the Create method on the returned struct.
+func NewLogArea(
 	ctx context.Context,
 	environmentrequest *v1alpha1.EnvironmentRequest,
 	namespace, name string,
 	spec v1alpha2.LogAreaSpec,
-) (*v1alpha2.LogArea, error) {
-	logger := logr.FromContextOrDiscard(ctx)
+) (*LogArea, error) {
 	var logArea v1alpha2.LogArea
 
-	logger.Info("Getting Kubernetes client")
-	cli, err := KubernetesClient()
-	if err != nil {
-		return nil, err
-	}
 	labels := map[string]string{
 		"app.kubernetes.io/name":    "log-area-provider",
 		"app.kubernetes.io/part-of": "etos",
@@ -133,7 +131,16 @@ func CreateLogArea(
 		Spec: spec,
 	}
 
-	return &logArea, cli.Create(ctx, &logArea)
+	return &LogArea{&logArea}, nil
+}
+
+// Create creates the LogArea resource in Kubernetes.
+func (l *LogArea) Create(ctx context.Context) error {
+	cli, err := KubernetesClient()
+	if err != nil {
+		return err
+	}
+	return cli.Create(ctx, l.LogArea)
 }
 
 // DeleteLogArea deletes an LogArea resource from Kubernetes.


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
#686 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
When moving environment variable generation into the provider package we created a small problem where, for example, an ETR job needs to be created before the ExecutionSpace is created in Kubernetes. Since we would not have the environment variables available the ETR could not start properly.
Breaking out generation and creation gives the possibility to first generate the ExecutionSpace, launch ETR and then create the ExecutionSpace.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
