### PR TITLE
Retry SSE connection on 502/504 transient errors

### DIFF
--- a/cli/src/etos_client/sse/v1/client.py
+++ b/cli/src/etos_client/sse/v1/client.py
@@ -29,13 +29,18 @@ from etos_client.shared.events import Event
 from .protocol import Shutdown, parse
 
 CHUNK_SIZE = 500
+# Status codes that indicate a transient (non-permanent) error and should be retried.
+# RETRY_AFTER_STATUS_CODES is {413, 429, 503}. 502 (Bad Gateway) and 504 (Gateway
+# Timeout) are added to cover the case where the SSE server is temporarily
+# unavailable, e.g. while restarting due to an upgrade or a crash.
+RETRY_STATUS_CODES = Retry.RETRY_AFTER_STATUS_CODES | {502, 504}
 RETRIES = Retry(
     total=None,
     read=0,
     connect=10,
     status=10,
     backoff_factor=1,
-    status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,  # 413, 429, 503
+    status_forcelist=RETRY_STATUS_CODES,
 )
 
 
@@ -124,7 +129,8 @@ class SSEClient:
                 status=20,
                 backoff_factor=2,  # Exponential backoff
                 backoff_max=120,  # Cap at 2 minutes
-                status_forcelist={413, 429, 503, 404},  # Include 404 for initial connection
+                # Include 404 for initial connection (test run not ready yet)
+                status_forcelist=RETRY_STATUS_CODES | {404},
             )
             self.logger.info("Connecting to SSE server")
             self.logger.info("Waiting for test run to start...")

--- a/cli/src/etos_client/sse/v2alpha/client.py
+++ b/cli/src/etos_client/sse/v2alpha/client.py
@@ -26,13 +26,18 @@ from urllib3.poolmanager import PoolManager
 from urllib3.util import Retry
 
 CHUNK_SIZE = 500
+# Status codes that indicate a transient (non-permanent) error and should be retried.
+# RETRY_AFTER_STATUS_CODES is {413, 429, 503}. 502 (Bad Gateway) and 504 (Gateway
+# Timeout) are added to cover the case where the SSE server is temporarily
+# unavailable, e.g. while restarting due to an upgrade or a crash.
+RETRY_STATUS_CODES = Retry.RETRY_AFTER_STATUS_CODES | {502, 504}
 RETRIES = Retry(
     total=None,
     read=0,
     connect=10,
     status=10,
     backoff_factor=1,
-    status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,  # 413, 429, 503
+    status_forcelist=RETRY_STATUS_CODES,
 )
 
 
@@ -117,7 +122,8 @@ class SSEClient:
                 status=20,
                 backoff_factor=2,  # Exponential backoff
                 backoff_max=120,  # Cap at 2 minutes
-                status_forcelist={413, 429, 503, 404},  # Include 404 for initial connection
+                # Include 404 for initial connection (test run not ready yet)
+                status_forcelist=RETRY_STATUS_CODES | {404},
             )
             self.logger.info("Connecting to SSE server")
             self.logger.info("Waiting for test run to start...")

--- a/cli/src/etos_client/sse/v2alpha/client.py
+++ b/cli/src/etos_client/sse/v2alpha/client.py
@@ -31,6 +31,9 @@ CHUNK_SIZE = 500
 # Timeout) are added to cover the case where the SSE server is temporarily
 # unavailable, e.g. while restarting due to an upgrade or a crash.
 RETRY_STATUS_CODES = Retry.RETRY_AFTER_STATUS_CODES | {502, 504}
+# During the initial connection 404 is also retried, since it means the test run
+# has not started yet.
+INITIAL_RETRY_STATUS_CODES = RETRY_STATUS_CODES | {404}
 RETRIES = Retry(
     total=None,
     read=0,
@@ -122,8 +125,7 @@ class SSEClient:
                 status=20,
                 backoff_factor=2,  # Exponential backoff
                 backoff_max=120,  # Cap at 2 minutes
-                # Include 404 for initial connection (test run not ready yet)
-                status_forcelist=RETRY_STATUS_CODES | {404},
+                status_forcelist=INITIAL_RETRY_STATUS_CODES,
             )
             self.logger.info("Connecting to SSE server")
             self.logger.info("Waiting for test run to start...")


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/697

### Description of the Change

The ETOS Client SSE client now treats `502 Bad Gateway` and `504 Gateway Timeout` as transient errors and retries the connection, so a restarting or temporarily unavailable SSE server (upgrade or crash) no longer aborts the client.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com