### PR TITLE
Delete suite runner job when testrun reaches its deadline

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -124,6 +124,12 @@ func (r *TestRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if testrun.Status.CompletionTime != nil {
 		// Delete suite runner job and environment requests after the testrun has completed.
 		jobManager := jobs.NewJob(r.Client, TestRunOwnerKey, testrun.GetName(), testrun.GetNamespace())
+		// Status must run before Delete to populate the job manager's list of
+		// owned jobs. Without it, Delete has no jobs to act on and leaks the suite runner job.
+		if _, err := jobManager.Status(ctx); err != nil {
+			logger.Error(err, "Failed to get suite runner job status, will retry")
+			return ctrl.Result{}, err
+		}
 		_ = jobManager.Delete(ctx)
 		_ = r.deleteEnvironmentRequests(ctx, testrun)
 		testrunCondition := meta.FindStatusCondition(testrun.Status.Conditions, status.StatusActive)


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/701

### Description of the Change

Ensures the suite runner job is deleted when a testrun completes by reaching its deadline, so the job no longer keeps running after the testrun is marked completed.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com