### PR TITLE
Remove unnecessary debug logs from RabbitMQ stream publisher

### DIFF
--- a/internal/messaging/rabbitmq.go
+++ b/internal/messaging/rabbitmq.go
@@ -131,7 +131,6 @@ func (s *rabbitMQStreamPublisher) Start() error {
 			go func() {
 				for _, msgStatus := range messageStatus {
 					if msgStatus.IsConfirmed() {
-						s.logger.V(1).Info("Message confirmed")
 						s.unConfirmed.Done()
 					} else {
 						s.logger.Error(msgStatus.GetError(), "Unconfirmed message")
@@ -173,7 +172,6 @@ func (s *rabbitMQStreamPublisher) Publish(identifier string, e events.Event) err
 		"meta":       e.EventMeta(),
 	}
 	s.unConfirmedMessages <- msg
-	s.logger.V(1).Info("Event published to unconfirmed channel")
 	return nil
 }
 
@@ -182,13 +180,11 @@ func (s *rabbitMQStreamPublisher) publish(done chan struct{}) {
 	for {
 		select {
 		case msg := <-s.unConfirmedMessages:
-			s.logger.V(1).Info("Publishing message to RabbitMQ stream")
 			if err := s.producer.Send(msg); err != nil {
 				s.logger.Error(err, "Failed to send message")
 				s.unConfirmed.Done()
 				continue
 			}
-			s.logger.V(1).Info("Published")
 		case <-done:
 			return
 		}


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/708

### Description of the Change

Removed the per-message `V(1)` debug logs from the RabbitMQ stream publisher, since they fire on every event and only add noise to OpenTelemetry traces. Error and lifecycle logs are kept.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com