### PR TITLE
Add read timeout to v0 SSE client to prevent hangs on stalled streams

### DIFF
--- a/cli/src/etos_client/sse/v1/client.py
+++ b/cli/src/etos_client/sse/v1/client.py
@@ -20,15 +20,23 @@ import time
 from json import JSONDecodeError
 from typing import Callable, Iterable, Optional
 
-from urllib3.exceptions import HTTPError, MaxRetryError
+from urllib3.exceptions import HTTPError, MaxRetryError, ReadTimeoutError
 from urllib3.poolmanager import PoolManager
-from urllib3.util import Retry
+from urllib3.util import Retry, Timeout
 
 from etos_client.shared.events import Event
 
 from .protocol import Shutdown, parse
 
 CHUNK_SIZE = 500
+# The SSE server emits a ping every 15 seconds. Without a socket read timeout a
+# half-open TCP connection (e.g. when the server pod is rescheduled, or a Jenkins
+# agent goes offline mid-run) would leave the blocking stream read hanging forever,
+# so the client would never reconnect and resume from Last-Event-ID. A read timeout
+# of four missed pings detects a dead connection while tolerating transient slowness.
+CONNECT_TIMEOUT = 30
+READ_TIMEOUT = 60
+STREAM_TIMEOUT = Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)
 # Status codes that indicate a transient (non-permanent) error and should be retried.
 # RETRY_AFTER_STATUS_CODES is {413, 429, 503}. 502 (Bad Gateway) and 504 (Gateway
 # Timeout) are added to cover the case where the SSE server is temporarily
@@ -160,6 +168,7 @@ class SSEClient:
                 headers=headers,
                 preload_content=False,
                 retries=retries,
+                timeout=STREAM_TIMEOUT,
             )
             self.__release = response.release_conn
         except MaxRetryError as exception:
@@ -271,6 +280,13 @@ class SSEClient:
                 if e.event:
                     yield e.event
                 self.close()  # close sets __shutdown to True, exiting the while loop.
+            except ReadTimeoutError:
+                self.logger.warning(
+                    "No data from the SSE server within %ds (connection likely dead). "
+                    "Reconnecting",
+                    READ_TIMEOUT,
+                )
+                self.reset()
             except HTTPError:
                 self.logger.debug("HTTP error from the SSE server, reconnecting", exc_info=True)
                 self.reset()


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/720

### Description of the Change

Adds a socket read timeout to the SSE v1 client so a half-open or stalled connection raises instead of blocking forever, triggering a reconnect with `Last-Event-ID`. This aligns the SSE v1 client with the SSE v2alpha client, which already applies a read timeout (added in https://github.com/eiffel-community/etos/pull/700).

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
