### PR TITLE
Render v1alpha SSE log timestamps in local time

### DIFF
--- a/cli/src/etos_client/etos/v1alpha/test_run/test_run.py
+++ b/cli/src/etos_client/etos/v1alpha/test_run/test_run.py
@@ -142,6 +142,8 @@ class TestRun:
             message,
             extra={
                 "rname": message.data.name,
-                "rtime": message.data.datestring.strftime("%Y-%m-%d %H:%M:%S"),
+                # Convert to local time so timestamps match the rest of the
+                # client output; core services emit UTC.
+                "rtime": message.data.datestring.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
             },
         )


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/722

### Description of the Change

The v1alpha (v2alpha SSE) client rendered remote log timestamps in the timezone provided by the source, so UTC `@timestamp` values from core services were shown in UTC while other lines used local time. The datestring is now converted to local time before formatting, making all timestamps consistent.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
