### PR TITLE
Emit log @timestamp in UTC regardless of process timezone

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/eiffel-community/etos/internal/messaging"
 	"github.com/eiffel-community/etos/pkg/messaging/events"
@@ -156,7 +157,12 @@ func addDefaults(opts zap.Options) zap.Options {
 	}
 
 	if opts.TimeEncoder == nil {
-		opts.TimeEncoder = zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.000Z")
+		// Always emit '@timestamp' in UTC. TimeEncoderOfLayout formats in the
+		// process' local timezone and the layout's 'Z' is a literal, so a non-UTC
+		// process would otherwise log local time labelled as UTC.
+		opts.TimeEncoder = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000Z"))
+		}
 	}
 	f := func(ecfg *zapcore.EncoderConfig) {
 		ecfg.EncodeTime = opts.TimeEncoder


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/724

### Description of the Change

The default zap time encoder in `pkg/logging` used `TimeEncoderOfLayout`, which formats `@timestamp` in the process' local timezone with a literal `Z`. A provider running in a non-UTC timezone therefore logged local time labelled as UTC. The encoder now converts to UTC before formatting, so `@timestamp` is always correct UTC regardless of the process timezone.

### Alternate Designs

Setting provider containers to `TZ=UTC` works around it per-image, but this fixes the root cause for all consumers of the library.

### Possible Drawbacks

None.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
