### PR TITLE
Reconcile ETOS client downloads against received artifacts

### DIFF
--- a/cli/src/etos_client/etos/v0/etos.py
+++ b/cli/src/etos_client/etos/v0/etos.py
@@ -172,6 +172,7 @@ class Etos:
         self.logger.info(
             "Downloaded a total of %d logs from test runners", len(log_downloader.downloads)
         )
+        log_downloader.reconciler.log_summary()
         self.logger.info("Archiving reports.")
         shutil.make_archive(
             str(artifact_dir.joinpath("reports").relative_to(Path.cwd())), "zip", report_dir
@@ -179,7 +180,7 @@ class Etos:
         self.logger.info("Reports: %s", report_dir)
         self.logger.info("Artifacts: %s", artifact_dir)
 
-        if log_downloader.failed:
+        if log_downloader.failed or log_downloader.reconciler.missing():
             return (False, None), "ETOS logs did not download successfully"
         return TestResults().get_results(events), None
 

--- a/cli/src/etos_client/etos/v1alpha/etos.py
+++ b/cli/src/etos_client/etos/v1alpha/etos.py
@@ -177,6 +177,7 @@ class Etos:
         self.logger.info(
             "Downloaded a total of %d logs from test runners", len(log_downloader.downloads)
         )
+        log_downloader.reconciler.log_summary()
         self.logger.info("Archiving reports.")
         shutil.make_archive(
             str(artifact_dir.joinpath("reports").relative_to(Path.cwd())), "zip", report_dir
@@ -184,7 +185,7 @@ class Etos:
         self.logger.info("Reports: %s", report_dir)
         self.logger.info("Artifacts: %s", artifact_dir)
 
-        if log_downloader.failed:
+        if log_downloader.failed or log_downloader.reconciler.missing():
             return Result(
                 verdict=Verdict.INCONCLUSIVE,
                 conclusion=Conclusion.FAILED,

--- a/cli/src/etos_client/shared/download_reconciler.py
+++ b/cli/src/etos_client/shared/download_reconciler.py
@@ -1,0 +1,122 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reconciliation of artifacts received from test runners against what was downloaded."""
+
+import logging
+from threading import Lock
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from etos_client.shared.downloader import Downloadable
+
+
+class DownloadReconciler:
+    """Reconcile artifacts received by the client against those actually downloaded.
+
+    The downloader reports three events to this class: an artifact was received for
+    download, an artifact was successfully downloaded and verified, or an artifact
+    failed to download. From those events the reconciler determines which received
+    artifacts never arrived intact.
+
+    The scope is limited to artifacts the client was told about: it verifies that every
+    artifact received (as a report/artifact event) was successfully downloaded and
+    integrity-verified. It does not verify that the test runners published an event for
+    every file they produced, nor does it compare against the raw upload/download counts.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self) -> None:
+        """Init."""
+        self.__lock = Lock()
+        self.__received: dict[str, "Downloadable"] = {}
+        self.__downloaded: set[str] = set()
+        self.failures: dict[str, str] = {}
+
+    def record_received(self, item: "Downloadable") -> None:
+        """Record that an artifact was received from a test runner for download."""
+        with self.__lock:
+            self.__received.setdefault(item.url, item)
+
+    def record_downloaded(self, item: "Downloadable") -> None:
+        """Record that an artifact was successfully downloaded and verified."""
+        with self.__lock:
+            self.__downloaded.add(item.url)
+
+    def record_failed(self, item: "Downloadable", reason: str) -> None:
+        """Record that an artifact failed to download, with the reason why."""
+        with self.__lock:
+            self.failures[item.url] = reason
+
+    @property
+    def expected(self) -> int:
+        """Number of unique artifacts received from the test runners for download."""
+        with self.__lock:
+            return len(self.__received)
+
+    def missing(self) -> list["Downloadable"]:
+        """Return artifacts that were received but not successfully downloaded.
+
+        An artifact is considered missing if it was received for download but never
+        completed a successful download and integrity verification.
+        """
+        with self.__lock:
+            downloaded = set(self.__downloaded)
+            received = dict(self.__received)
+        return [item for url, item in received.items() if url not in downloaded]
+
+    def breakdown(self) -> dict[str, tuple[int, int]]:
+        """Return per-sub-suite (downloaded, expected) counts.
+
+        Artifacts are grouped by their destination directory, which corresponds to
+        the sub-suite they belong to. Returns a mapping of directory to a
+        (downloaded, expected) tuple.
+        """
+        with self.__lock:
+            downloaded = set(self.__downloaded)
+            received = dict(self.__received)
+        counts: dict[str, tuple[int, int]] = {}
+        for url, item in received.items():
+            key = str(item.path)
+            done, expected = counts.get(key, (0, 0))
+            counts[key] = (done + (1 if url in downloaded else 0), expected + 1)
+        return counts
+
+    def log_summary(self) -> None:
+        """Log a reconciliation summary of received vs. downloaded artifacts."""
+        missing = self.missing()
+        if missing:
+            self.logger.error(
+                "Artifact reconciliation FAILED: %d of %d received artifacts were not "
+                "downloaded successfully.",
+                len(missing),
+                self.expected,
+            )
+            for item in missing:
+                self.logger.error(
+                    "Missing artifact %r from %s (%s)",
+                    item.name,
+                    item.url,
+                    self.failures.get(item.url, "not downloaded"),
+                )
+        else:
+            self.logger.info(
+                "Artifact reconciliation OK: all %d received artifacts were downloaded "
+                "successfully.",
+                self.expected,
+            )
+        for directory, (downloaded, expected) in sorted(self.breakdown().items()):
+            self.logger.info("  %s: %d/%d artifacts downloaded", directory, downloaded, expected)

--- a/cli/src/etos_client/shared/downloader.py
+++ b/cli/src/etos_client/shared/downloader.py
@@ -33,6 +33,8 @@ from requests.exceptions import HTTPError
 
 from etos_lib.lib.http import Http
 
+from etos_client.shared.download_reconciler import DownloadReconciler
+
 MAX_RETRIES = (
     10  # With 1 as backoff_factor, the total wait time between retries will be 1023 seconds
 )
@@ -96,20 +98,30 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         self.__http = Http(retry=HTTP_RETRY_PARAMETERS)
         self.failed: bool = False
         self.downloads: set[str] = set()
+        self.reconciler = DownloadReconciler()
 
     def __download(self, item: Downloadable) -> None:
         """Download files."""
         self.logger.debug("Downloading %r", item)
-        # retry rules are set in the Http client
-        response = self.__http.get(item.url, stream=True)
-        if self.__download_ok(response):
+        try:
+            # retry rules are set in the Http client
+            response = self.__http.get(item.url, stream=True)
+            if not self.__download_ok(response):
+                self.__record_failure(item, "download request did not succeed")
+                return
             self.__save_file(item, response)
-            self.logger.debug("Item downloaded %r", item)
+        except IntegrityError as integrity_error:
+            self.__record_failure(item, str(integrity_error))
             return
+        self.reconciler.record_downloaded(item)
+        self.logger.debug("Item downloaded %r", item)
+
+    def __record_failure(self, item: Downloadable, reason: str) -> None:
+        """Record a failed download so it can be reconciled and reported to the user."""
         with self.__lock:
             self.failed = True
-        self.logger.critical("Failed to download %r", item)
-        return
+        self.reconciler.record_failed(item, reason)
+        self.logger.critical("Failed to download %r: %s", item, reason)
 
     def __save_file(self, item: Downloadable, response: requests.Response) -> None:
         """Save downloaded file data to disk."""
@@ -123,8 +135,6 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
             index += 1
             download_path = download_path.with_name(f"{index}_{original_name}")
         self.logger.debug("Saving file %s", download_path)
-        with self.__lock:
-            self.downloads.add(str(download_path))
         with open(download_path, "wb+") as report:
             for chunk in response:
                 report.write(chunk)
@@ -133,6 +143,10 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         except IntegrityError:
             download_path.unlink()
             raise
+        # Only count a file as downloaded once it has been fully written and its
+        # integrity verified, so the count reflects what actually reached the client.
+        with self.__lock:
+            self.downloads.add(str(download_path))
 
     def __verify(self, item: Downloadable, path: Path):
         """Verify the checksum of the downloaded item.
@@ -254,3 +268,4 @@ class Downloader(Thread):  # pylint:disable=too-many-instance-attributes
         if item.url not in self.__queued:
             self.__download_queue.put_nowait(item)
             self.__queued.append(item.url)
+            self.reconciler.record_received(item)

--- a/cli/tests/test_download_reconciler.py
+++ b/cli/tests/test_download_reconciler.py
@@ -1,0 +1,78 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the standalone download reconciler."""
+
+from pathlib import Path
+
+from etos_client.shared.downloader import Downloadable
+from etos_client.shared.download_reconciler import DownloadReconciler
+
+
+def _item(url: str, name: str, directory: str) -> Downloadable:
+    """Build a Downloadable pointing at a sub-suite directory."""
+    return Downloadable(url=url, name=name, path=Path(directory))
+
+
+def test_received_and_downloaded_is_not_missing():
+    """An artifact recorded as downloaded is not reported missing."""
+    reconciliation = DownloadReconciler()
+    item = _item("http://example/a.txt", "a.txt", "SubSuite_0")
+
+    reconciliation.record_received(item)
+    reconciliation.record_downloaded(item)
+
+    assert reconciliation.expected == 1
+    assert reconciliation.missing() == []
+
+
+def test_received_but_failed_is_missing():
+    """An artifact that failed to download is reported missing with its reason."""
+    reconciliation = DownloadReconciler()
+    item = _item("http://example/a.txt", "a.txt", "SubSuite_0")
+
+    reconciliation.record_received(item)
+    reconciliation.record_failed(item, "boom")
+
+    missing = reconciliation.missing()
+    assert [entry.url for entry in missing] == [item.url]
+    assert reconciliation.failures[item.url] == "boom"
+
+
+def test_breakdown_groups_by_directory():
+    """Counts are grouped per destination directory (sub-suite)."""
+    reconciliation = DownloadReconciler()
+    item_a = _item("http://example/a.txt", "a.txt", "SubSuite_0")
+    item_b = _item("http://example/b.txt", "b.txt", "SubSuite_0")
+    item_c = _item("http://example/c.txt", "c.txt", "SubSuite_1")
+
+    for item in (item_a, item_b, item_c):
+        reconciliation.record_received(item)
+    reconciliation.record_downloaded(item_a)
+
+    breakdown = reconciliation.breakdown()
+    assert breakdown["SubSuite_0"] == (1, 2)
+    assert breakdown["SubSuite_1"] == (0, 1)
+
+
+def test_received_dedups_by_url():
+    """Recording the same URL twice only expects it once."""
+    reconciliation = DownloadReconciler()
+    item = _item("http://example/a.txt", "a.txt", "SubSuite_0")
+
+    reconciliation.record_received(item)
+    reconciliation.record_received(item)
+
+    assert reconciliation.expected == 1

--- a/cli/tests/test_downloader.py
+++ b/cli/tests/test_downloader.py
@@ -1,0 +1,139 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ETOS client download reconciliation."""
+
+import hashlib
+from unittest.mock import MagicMock
+
+from etos_client.shared.downloader import Downloadable, Downloader
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed requests.Response."""
+
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self):
+        """Pretend the HTTP request succeeded."""
+        return None
+
+    def __iter__(self):
+        """Yield the body as a single chunk."""
+        yield self.content
+
+
+def _downloader(content: bytes) -> Downloader:
+    """Create a Downloader whose HTTP client returns a fixed response."""
+    downloader = Downloader()
+    http = MagicMock()
+    http.get.return_value = _FakeResponse(content)
+    # Replace the name-mangled private Http client.
+    downloader._Downloader__http = http  # pylint:disable=protected-access
+    return downloader
+
+
+def _download(downloader: Downloader, item: Downloadable) -> None:
+    """Invoke the private download method synchronously."""
+    downloader._Downloader__download(item)  # pylint:disable=protected-access
+
+
+def test_successful_download_is_counted_and_not_missing(tmp_path):
+    """A verified download is counted once and reported as not missing."""
+    content = b"hello"
+    item = Downloadable(url="http://example/a.txt", name="a.txt", path=tmp_path)
+    downloader = _downloader(content)
+
+    downloader.queue_download(item)
+    _download(downloader, item)
+
+    assert downloader.reconciler.expected == 1
+    assert len(downloader.downloads) == 1
+    assert downloader.reconciler.missing() == []
+    assert downloader.failed is False
+    assert (tmp_path / "a.txt").read_bytes() == content
+
+
+def test_correct_checksum_passes(tmp_path):
+    """A download whose checksum matches is counted."""
+    content = b"hello world"
+    digest = hashlib.sha256(content).hexdigest()
+    item = Downloadable(
+        url="http://example/b.txt",
+        name="b.txt",
+        path=tmp_path,
+        checksums={"SHA-256": digest},
+    )
+    downloader = _downloader(content)
+
+    downloader.queue_download(item)
+    _download(downloader, item)
+
+    assert len(downloader.downloads) == 1
+    assert downloader.reconciler.missing() == []
+
+
+def test_integrity_failure_is_missing_and_not_counted(tmp_path):
+    """A checksum mismatch is not counted, is reported missing, and marks failure."""
+    content = b"hello"
+    item = Downloadable(
+        url="http://example/a.txt",
+        name="a.txt",
+        path=tmp_path,
+        checksums={"SHA-256": "deadbeef"},
+    )
+    downloader = _downloader(content)
+
+    downloader.queue_download(item)
+    _download(downloader, item)
+
+    assert len(downloader.downloads) == 0
+    assert downloader.failed is True
+    missing = downloader.reconciler.missing()
+    assert len(missing) == 1
+    assert missing[0].url == item.url
+    assert item.url in downloader.reconciler.failures
+    # The corrupt file must not be left on disk.
+    assert not (tmp_path / "a.txt").exists()
+
+
+def test_queue_dedup_by_url(tmp_path):
+    """Queuing the same URL twice only expects it once."""
+    item = Downloadable(url="http://example/c.txt", name="c.txt", path=tmp_path)
+    downloader = _downloader(b"x")
+
+    downloader.queue_download(item)
+    downloader.queue_download(item)
+
+    assert downloader.reconciler.expected == 1
+
+
+def test_breakdown_groups_by_sub_suite(tmp_path):
+    """The breakdown groups downloaded/expected counts per destination directory."""
+    suite_0 = tmp_path / "SubSuite_0"
+    suite_1 = tmp_path / "SubSuite_1"
+    item_a = Downloadable(url="http://example/a.txt", name="a.txt", path=suite_0)
+    item_b = Downloadable(url="http://example/b.txt", name="b.txt", path=suite_0)
+    item_c = Downloadable(url="http://example/c.txt", name="c.txt", path=suite_1)
+    downloader = _downloader(b"data")
+
+    for item in (item_a, item_b, item_c):
+        downloader.queue_download(item)
+        _download(downloader, item)
+
+    breakdown = downloader.reconciler.breakdown()
+    assert breakdown[str(suite_0)] == (2, 2)
+    assert breakdown[str(suite_1)] == (1, 1)


### PR DESCRIPTION
### Applicable Issues

Relates to https://github.com/eiffel-community/etos/issues/726

### Description of the Change

Adds a `DownloadReconciler` that tracks the artifacts the client receives (report/artifact events) against those it successfully downloads and integrity-verifies. After a test run the client logs a reconciliation summary with a per-sub-suite breakdown, reports any artifacts that did not arrive intact, and fails the run if some are missing. The download counter is also corrected to only count a file once it has been written and verified.

### Alternate Designs

The reconciliation logic was extracted into its own class to keep the changes to the existing `Downloader` and client classes minimal.

### Possible Drawbacks

This verifies only what the client was told about; it does not verify that every produced file was announced to the client. That broader guarantee is intended for follow-up changes.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
